### PR TITLE
CreationTime - Update insertions to not set creation time

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,6 +1,6 @@
 CREATE TABLE users (
   user_id BIGSERIAL,
-  user_creation_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  user_creation_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
   user_hashed_email TEXT NOT NULL,
   user_encrypted_pii TEXT NOT NULL,
   CONSTRAINT users_unique_user_hashed_email UNIQUE (user_hashed_email),
@@ -9,7 +9,7 @@ CREATE TABLE users (
 
 CREATE TABLE admins (
   admin_id BIGSERIAL,
-  admin_creation_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  admin_creation_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
   admin_hashed_email TEXT NOT NULL,
   admin_encrypted_pii TEXT NOT NULL,
   CONSTRAINT admins_unique_admin_hashed_email UNIQUE (admin_hashed_email),
@@ -18,7 +18,7 @@ CREATE TABLE admins (
 
 CREATE TABLE vets (
   vet_id BIGSERIAL,
-  vet_creation_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  vet_creation_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
   vet_email TEXT NOT NULL,
   vet_name TEXT NOT NULL,
   vet_phone_number TEXT NOT NULL,
@@ -32,7 +32,7 @@ CREATE TYPE t_dog_antigen_presence AS ENUM ('POSITIVE', 'NEGATIVE', 'UNKNOWN');
 
 CREATE TABLE dogs (
   dog_id BIGSERIAL,
-  dog_creation_time TIMESTAMP WITH TIME ZONE NOT NULL,
+  dog_creation_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
   dog_status TEXT NOT NULL,
   user_id BIGINT NOT NULL,
   dog_encrypted_oii TEXT NOT NULL,

--- a/src/lib/data/dbAdmins.ts
+++ b/src/lib/data/dbAdmins.ts
@@ -8,10 +8,9 @@ export async function dbInsertAdmin(
   const sql = `
     INSERT INTO admins (
       admin_hashed_email,
-      admin_encrypted_pii,
-      admin_creation_time
+      admin_encrypted_pii
     )
-    VALUES ($1, $2, CURRENT_TIMESTAMP)
+    VALUES ($1, $2)
     RETURNING admin_id, admin_creation_time
   `;
   const res = await dbQuery(ctx, sql, [

--- a/src/lib/data/dbDogs.ts
+++ b/src/lib/data/dbDogs.ts
@@ -14,11 +14,9 @@ export async function dbInsertDog(
       dog_breed,
       dog_birth_month,
       dog_gender,
-      dog_dea1_point1,
-
-      dog_creation_time
+      dog_dea1_point1
     )
-    VALUES ($1, $2, $3, $4, $5, $6, $7, CURRENT_TIMESTAMP)
+    VALUES ($1, $2, $3, $4, $5, $6, $7)
     RETURNING dog_id, dog_creation_time
   `;
   const res = await dbQuery(ctx, sql, [

--- a/src/lib/data/dbUsers.ts
+++ b/src/lib/data/dbUsers.ts
@@ -8,10 +8,9 @@ export async function dbInsertUser(
   const sql = `
   INSERT INTO users (
     user_hashed_email,
-    user_encrypted_pii,
-    user_creation_time
+    user_encrypted_pii
   )
-  VALUES ($1, $2, CURRENT_TIMESTAMP)
+  VALUES ($1, $2)
   RETURNING
     user_id,
     user_creation_time

--- a/src/lib/data/dbVets.ts
+++ b/src/lib/data/dbVets.ts
@@ -10,10 +10,9 @@ export async function dbInsertVet(
       vet_email,
       vet_name,
       vet_phone_number,
-      vet_address,
-      vet_creation_time
+      vet_address
     )
-    VALUES ($1, $2, $3, $4, CURRENT_TIMESTAMP)
+    VALUES ($1, $2, $3, $4)
     RETURNING vet_id, vet_creation_time
   `;
   const res = await dbQuery(ctx, sql, [


### PR DESCRIPTION
The schema now specifies CURRENT_TIMESTAMP as default value for all creation_time columns.