### PR TITLE
RefactorDbLayerTests - Refactor the tests in dbLayer.test.ts

### DIFF
--- a/src/lib/bark-utils.ts
+++ b/src/lib/bark-utils.ts
@@ -1,0 +1,9 @@
+export function guaranteed<T>(arg: T | undefined | null): T {
+  if (arg === undefined) {
+    throw Error("arg is undefined");
+  }
+  if (arg === null) {
+    throw Error("arg is null");
+  }
+  return arg;
+}

--- a/src/lib/data/mappers.ts
+++ b/src/lib/data/mappers.ts
@@ -10,21 +10,21 @@ import {
 } from "./models";
 
 export function toUserSpec(user: User): UserSpec {
-  const { userId, userCreationTime, ...spec } = user;
+  const { userId, userCreationTime, userModificationTime, ...spec } = user;
   return spec;
 }
 
 export function toDogSpec(dog: Dog): DogSpec {
-  const { userId, dogId, dogCreationTime, ...spec } = dog;
+  const { userId, dogId, dogCreationTime, dogModificationTime, ...spec } = dog;
   return spec;
 }
 
 export function toAdminSpec(admin: Admin): AdminSpec {
-  const { adminId, adminCreationTime, ...spec } = admin;
+  const { adminId, adminCreationTime, adminModificationTime, ...spec } = admin;
   return spec;
 }
 
 export function toVetSpec(vet: Vet): VetSpec {
-  const { vetId, vetCreationTime, ...spec } = vet;
+  const { vetId, vetCreationTime, vetModificationTime, ...spec } = vet;
   return spec;
 }

--- a/src/lib/stringutils.ts
+++ b/src/lib/stringutils.ts
@@ -1,6 +1,0 @@
-export function guaranteed(arg: string | undefined): string {
-  if (arg === undefined) {
-    throw Error("arg is undefined");
-  }
-  return arg;
-}

--- a/tests/SecretEncryptionService.test.ts
+++ b/tests/SecretEncryptionService.test.ts
@@ -1,5 +1,5 @@
 import { SecretEncryptionService } from "@/lib/services/encryption";
-import { guaranteed } from "@/lib/stringutils";
+import { guaranteed } from "@/lib/bark-utils";
 
 describe("SecretEncryptionService", () => {
   it("should decrypt encrypted data back to original data", async () => {

--- a/tests/dbLayer.test.ts
+++ b/tests/dbLayer.test.ts
@@ -38,10 +38,12 @@ import { guaranteed } from "@/lib/bark-utils";
  * Database Layer refers to the code in lib/data.
  */
 describe("Database Layer", () => {
-  describe("DogStatus enumeration", () => {
-    it("is an enumeration of strings", () => {
-      expect(DogStatus.NEW_PROFILE).toBe("NEW_PROFILE");
-      expect(typeof DogStatus.NEW_PROFILE).toBe("string");
+  describe("models", () => {
+    describe("DogStatus enumeration", () => {
+      it("is an enumeration of strings", () => {
+        expect(DogStatus.NEW_PROFILE).toBe("NEW_PROFILE");
+        expect(typeof DogStatus.NEW_PROFILE).toBe("string");
+      });
     });
   });
   describe("dbUsers", () => {

--- a/tests/dbLayer.test.ts
+++ b/tests/dbLayer.test.ts
@@ -65,7 +65,7 @@ describe("Database Layer", () => {
         await withDb(async (db) => {
           const userGen = await dbInsertUser(db, userSpec(1));
           const user = await dbSelectUser(db, userGen.userId);
-          expect(user).not.toBeNull()
+          expect(user).not.toBeNull();
           expect(user?.userCreationTime).toEqual(userGen.userCreationTime);
           expect(user?.userModificationTime).toEqual(userGen.userCreationTime);
           const spec = toUserSpec(guaranteed(user));
@@ -202,41 +202,59 @@ describe("Database Layer", () => {
     });
   });
   describe("dbAdmins", () => {
-    it("should support insert and select", async () => {
-      await withDb(async (db) => {
-        const adminGen = await dbInsertAdmin(db, adminSpec(1));
-        const admin = await dbSelectAdmin(db, adminGen.adminId);
-        if (!admin) fail("admin is null");
-        expect(admin.adminCreationTime).toBeTruthy();
-        expect(admin.adminModificationTime).toBeTruthy();
-        expect(admin.adminModificationTime).toEqual(admin.adminCreationTime);
-        const spec = toAdminSpec(admin);
-        expect(spec).toMatchObject(adminSpec(1));
+    describe("dbInsertAdmin", () => {
+      it("should insert an admin", async () => {
+        await withDb(async (db) => {
+          const adminGen = await dbInsertAdmin(db, adminSpec(1));
+          expect(adminGen.adminCreationTime).toBeTruthy();
+          expect(adminGen.adminModificationTime).toBeTruthy();
+          expect(adminGen.adminModificationTime).toEqual(
+            adminGen.adminCreationTime,
+          );
+        });
       });
     });
-    it("should return null when admin does not exist", async () => {
-      await withDb(async (db) => {
-        const admin = await dbSelectAdmin(db, "111");
-        expect(admin).toBeNull();
+    describe("dbSelectAdmin", () => {
+      it("should return admin matching the adminId", async () => {
+        await withDb(async (db) => {
+          const adminGen = await dbInsertAdmin(db, adminSpec(1));
+          const admin = await dbSelectAdmin(db, adminGen.adminId);
+          expect(admin).not.toBeNull();
+          expect(admin?.adminCreationTime).toBeTruthy();
+          expect(admin?.adminModificationTime).toBeTruthy();
+          expect(admin?.adminModificationTime).toEqual(
+            admin?.adminCreationTime,
+          );
+          const spec = toAdminSpec(guaranteed(admin));
+          expect(spec).toMatchObject(adminSpec(1));
+        });
+      });
+      it("should return null when no admin matches the adminId", async () => {
+        await withDb(async (db) => {
+          const admin = await dbSelectAdmin(db, "111");
+          expect(admin).toBeNull();
+        });
       });
     });
-    it("should support retrieval of adminId by hashed email", async () => {
-      await withDb(async (db) => {
-        const adminGen = await dbInsertAdmin(db, adminSpec(1));
-        const adminId = await dbSelectAdminIdByAdminHashedEmail(
-          db,
-          adminSpec(1).adminHashedEmail,
-        );
-        expect(adminId).toEqual(adminGen.adminId);
+    describe("dbSelectAdminIdByAdminHashedEmail", () => {
+      it("should return adminId matching the hashed email", async () => {
+        await withDb(async (db) => {
+          const adminGen = await dbInsertAdmin(db, adminSpec(1));
+          const adminId = await dbSelectAdminIdByAdminHashedEmail(
+            db,
+            adminSpec(1).adminHashedEmail,
+          );
+          expect(adminId).toEqual(adminGen.adminId);
+        });
       });
-    });
-    it("should return null adminId when admin does not exist that has the hashed email", async () => {
-      await withDb(async (db) => {
-        const adminId = await dbSelectAdminIdByAdminHashedEmail(
-          db,
-          "not_found",
-        );
-        expect(adminId).toBeNull();
+      it("should return null when no admin matches the hashed email", async () => {
+        await withDb(async (db) => {
+          const adminId = await dbSelectAdminIdByAdminHashedEmail(
+            db,
+            "not_found",
+          );
+          expect(adminId).toBeNull();
+        });
       });
     });
   });

--- a/tests/dbLayer.test.ts
+++ b/tests/dbLayer.test.ts
@@ -259,35 +259,49 @@ describe("Database Layer", () => {
     });
   });
   describe("dbVets", () => {
-    it("should support insert and select", async () => {
-      await withDb(async (db) => {
-        const vetGen = await dbInsertVet(db, vetSpec(1));
-        const vet = await dbSelectVet(db, vetGen.vetId);
-        if (!vet) fail("vet is null");
-        expect(vet.vetCreationTime).toBeTruthy();
-        expect(vet.vetModificationTime).toBeTruthy();
-        expect(vet.vetModificationTime).toEqual(vet.vetCreationTime);
-        const spec = toVetSpec(vet);
-        expect(spec).toMatchObject(vetSpec(1));
+    describe("dbInsertVet", () => {
+      it("should return VetGen", async () => {
+        await withDb(async (db) => {
+          const vetGen = await dbInsertVet(db, vetSpec(1));
+          expect(vetGen.vetCreationTime).toBeTruthy();
+          expect(vetGen.vetModificationTime).toBeTruthy();
+          expect(vetGen.vetModificationTime).toEqual(vetGen.vetCreationTime);
+        });
       });
     });
-    it("should return null when vet does not exist", async () => {
-      await withDb(async (db) => {
-        const vet = await dbSelectVet(db, "111");
-        expect(vet).toBeNull();
+    describe("dbSelectVet", () => {
+      it("should return vet matching the vetId", async () => {
+        await withDb(async (db) => {
+          const vetGen = await dbInsertVet(db, vetSpec(1));
+          const vet = await dbSelectVet(db, vetGen.vetId);
+          expect(vet).not.toBeNull();
+          expect(vet?.vetCreationTime).toBeTruthy();
+          expect(vet?.vetModificationTime).toBeTruthy();
+          expect(vet?.vetModificationTime).toEqual(vet?.vetCreationTime);
+          const spec = toVetSpec(guaranteed(vet));
+          expect(spec).toMatchObject(vetSpec(1));
+        });
+      });
+      it("should return null no vet matches the vetId", async () => {
+        await withDb(async (db) => {
+          const vet = await dbSelectVet(db, "111");
+          expect(vet).toBeNull();
+        });
       });
     });
-    it("should support retrieval of vet ID by email", async () => {
-      await withDb(async (db) => {
-        const vetGen = await dbInsertVet(db, vetSpec(1));
-        const vetId = await dbSelectVetIdByEmail(db, vetSpec(1).vetEmail);
-        expect(vetId).toEqual(vetGen.vetId);
+    describe("dbSelectVetIdByEmail", () => {
+      it("should return vetId matching the email", async () => {
+        await withDb(async (db) => {
+          const vetGen = await dbInsertVet(db, vetSpec(1));
+          const vetId = await dbSelectVetIdByEmail(db, vetSpec(1).vetEmail);
+          expect(vetId).toEqual(vetGen.vetId);
+        });
       });
-    });
-    it("should return null when no vet exists with the email", async () => {
-      await withDb(async (db) => {
-        const vetId = await dbSelectVetIdByEmail(db, "notavet@vet.com");
-        expect(vetId).toBeNull();
+      it("should return null when no vet matches the email", async () => {
+        await withDb(async (db) => {
+          const vetId = await dbSelectVetIdByEmail(db, "notavet@vet.com");
+          expect(vetId).toBeNull();
+        });
       });
     });
   });


### PR DESCRIPTION
Changes

(1) Refactored the tests in `dbLayer.test.ts` to be grouped by their respective module and function. E.g. dbUsers/dbInsertUser. While the original plan was to split `dbLayer.test.ts` into files like `dbUsers.test.ts`, we decided against this so that the fixtures (currently private) do not need to be exported from some common file.

(2) A bug in mappers.ts was fixed. Great!

(3) The `guaranteed()` function from `stringutils.ts` has been made generic for any type T. Consequently, module has been renamed to `bark-utils.ts`. The reason for the `bark-` prefix is because there's an existing `utils.ts`—I believe it was inserted by shadcn-ui.

