### PR TITLE
AdminCan - Implement AdminActor canThis canThat methods.

### DIFF
--- a/src/app/api/dangerous/admins/route.ts
+++ b/src/app/api/dangerous/admins/route.ts
@@ -14,7 +14,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   const piiEncryptionService = await APP.getPiiEncryptionService();
   const adminHashedEmail = await emailHashService.getHashHex(pii.adminEmail);
   const adminEncryptedPii = await encryptAdminPii(pii, piiEncryptionService);
-  const spec: AdminSpec = { adminHashedEmail, adminEncryptedPii, ...ADMIN_NO_PERMISSIONS };
+  const spec: AdminSpec = {
+    adminHashedEmail,
+    adminEncryptedPii,
+    ...ADMIN_NO_PERMISSIONS,
+  };
   const dbPool = await APP.getDbPool();
   const gen = await dbInsertAdmin(dbPool, spec);
   return NextResponse.json(gen);

--- a/src/lib/admin/admin-actor.ts
+++ b/src/lib/admin/admin-actor.ts
@@ -37,6 +37,9 @@ export class AdminActor {
   }
 
   public async getOwnAdmin(): Promise<Admin | null> {
+    // Caches own admin. It is safe to do this because a new AdminActor is
+    // created on every server request as part of session validation; starting
+    // from getAuthenticatedAdminActor to new AdminActor in AdminActorFactory.
     if (this.promisedAdmin === null) {
       this.promisedAdmin = dbSelectAdmin(this.getDbPool(), this.getAdminId());
     }

--- a/src/lib/admin/admin-actor.ts
+++ b/src/lib/admin/admin-actor.ts
@@ -17,6 +17,7 @@ export type AdminActorConfig = {
 export class AdminActor {
   private adminId: string;
   private config: AdminActorConfig;
+  private promisedAdmin: Promise<Admin | null> | null = null;
 
   constructor(adminId: string, config: AdminActorConfig) {
     this.adminId = adminId;
@@ -36,7 +37,10 @@ export class AdminActor {
   }
 
   public async getOwnAdmin(): Promise<Admin | null> {
-    return dbSelectAdmin(this.getDbPool(), this.getAdminId());
+    if (this.promisedAdmin === null) {
+      this.promisedAdmin = dbSelectAdmin(this.getDbPool(), this.getAdminId());
+    }
+    return this.promisedAdmin;
   }
 
   public async getOwnPii(): Promise<AdminPii | null> {
@@ -52,18 +56,22 @@ export class AdminActor {
   }
 
   public async canManageAdminAccounts(): Promise<boolean> {
-    return false;
+    const admin = await this.getOwnAdmin();
+    return admin ? admin.adminCanManageAdminAccounts : false;
   }
 
   public async canManageVetAccounts(): Promise<boolean> {
-    return false;
+    const admin = await this.getOwnAdmin();
+    return admin ? admin.adminCanManageVetAccounts : false;
   }
 
   public async canManageUserAccounts(): Promise<boolean> {
-    return false;
+    const admin = await this.getOwnAdmin();
+    return admin ? admin.adminCanManageUserAccounts : false;
   }
 
   public async canManageDonors(): Promise<boolean> {
-    return false;
+    const admin = await this.getOwnAdmin();
+    return admin ? admin.adminCanManageDonors : false;
   }
 }

--- a/src/lib/admin/admin-actor.ts
+++ b/src/lib/admin/admin-actor.ts
@@ -36,7 +36,7 @@ export class AdminActor {
     return this.config.piiEncryptionService;
   }
 
-  public async getOwnAdmin(): Promise<Admin | null> {
+  public getOwnAdmin(): Promise<Admin | null> {
     // Caches own admin. It is safe to do this because a new AdminActor is
     // created on every server request as part of session validation; starting
     // from getAuthenticatedAdminActor to new AdminActor in AdminActorFactory.

--- a/src/lib/admin/admin-actor.ts
+++ b/src/lib/admin/admin-actor.ts
@@ -50,4 +50,20 @@ export class AdminActor {
     );
     return pii;
   }
+
+  public async canManageAdminAccounts(): Promise<boolean> {
+    return false;
+  }
+
+  public async canManageVetAccounts(): Promise<boolean> {
+    return false;
+  }
+
+  public async canManageUserAccounts(): Promise<boolean> {
+    return false;
+  }
+
+  public async canManageDonors(): Promise<boolean> {
+    return false;
+  }
 }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,5 @@
 import { NextAuthOptions, getServerSession } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
-import { Err, Ok, Result } from "./result";
 import APP from "./app";
 import { AdminActor } from "./admin/admin-actor";
 import { VetActor } from "./vet/vet-actor";

--- a/src/lib/data/db-models.ts
+++ b/src/lib/data/db-models.ts
@@ -93,7 +93,7 @@ export const ADMIN_NO_PERMISSIONS: AdminPermissions = {
   adminCanManageVetAccounts: false,
   adminCanManageUserAccounts: false,
   adminCanManageDonors: false,
-}
+};
 
 export type AdminSpec = AdminPersonalData & AdminPermissions;
 

--- a/tests/AdminActor.test.ts
+++ b/tests/AdminActor.test.ts
@@ -61,4 +61,44 @@ describe("AdminActor", () => {
       expect(await actor.canManageDonors()).toBe(false);
     });
   });
+  it("can manage admin accounts with required permissions", async () => {
+    await withDb(async (db) => {
+      const admin = await insertAdmin(1, db, {
+        adminCanManageAdminAccounts: true,
+      });
+      const config = getAdminActorConfig(db);
+      const actor = new AdminActor(admin.adminId, config);
+      expect(await actor.canManageAdminAccounts()).toBe(true);
+    });
+  });
+  it("can manage vet accounts with required permissions", async () => {
+    await withDb(async (db) => {
+      const admin = await insertAdmin(1, db, {
+        adminCanManageVetAccounts: true,
+      });
+      const config = getAdminActorConfig(db);
+      const actor = new AdminActor(admin.adminId, config);
+      expect(await actor.canManageVetAccounts()).toBe(true);
+    });
+  });
+  it("can manage user accounts with required permissions", async () => {
+    await withDb(async (db) => {
+      const admin = await insertAdmin(1, db, {
+        adminCanManageUserAccounts: true,
+      });
+      const config = getAdminActorConfig(db);
+      const actor = new AdminActor(admin.adminId, config);
+      expect(await actor.canManageUserAccounts()).toBe(true);
+    });
+  });
+  it("can manage donors with required permissions", async () => {
+    await withDb(async (db) => {
+      const admin = await insertAdmin(1, db, {
+        adminCanManageDonors: true,
+      });
+      const config = getAdminActorConfig(db);
+      const actor = new AdminActor(admin.adminId, config);
+      expect(await actor.canManageDonors()).toBe(true);
+    });
+  });
 });

--- a/tests/AdminActor.test.ts
+++ b/tests/AdminActor.test.ts
@@ -12,6 +12,17 @@ describe("AdminActor", () => {
       expect(ownAdmin).toEqual(admin);
     });
   });
+  it("caches own admin", async () => {
+    await withDb(async (db) => {
+      const admin = await insertAdmin(1, db);
+      const config = getAdminActorConfig(db);
+      const actor = new AdminActor(admin.adminId, config);
+      const promise1 = actor.getOwnAdmin();
+      const promise2 = actor.getOwnAdmin();
+      const promises = await Promise.all([promise1, promise2]);
+      expect(promises[0]).toBe(promises[1]);
+    });
+  });
   it("can retrieve its own PII", async () => {
     await withDb(async (db) => {
       const admin = await insertAdmin(2, db);

--- a/tests/AdminActor.test.ts
+++ b/tests/AdminActor.test.ts
@@ -1,11 +1,11 @@
 import { withDb } from "./_db_helpers";
 import { AdminActor } from "@/lib/admin/admin-actor";
-import { createAdmin, getAdminActorConfig, adminPii } from "./_fixtures";
+import { insertAdmin, getAdminActorConfig, adminPii } from "./_fixtures";
 
 describe("AdminActor", () => {
   it("can retrieve its own actor data from the database", async () => {
     await withDb(async (db) => {
-      const admin = await createAdmin(1, db);
+      const admin = await insertAdmin(1, db);
       const config = getAdminActorConfig(db);
       const actor = new AdminActor(admin.adminId, config);
       const ownAdmin = await actor.getOwnAdmin();
@@ -14,11 +14,21 @@ describe("AdminActor", () => {
   });
   it("can retrieve its own PII", async () => {
     await withDb(async (db) => {
-      const admin = await createAdmin(1, db);
+      const admin = await insertAdmin(2, db);
       const config = getAdminActorConfig(db);
       const actor = new AdminActor(admin.adminId, config);
       const ownPii = await actor.getOwnPii();
-      expect(ownPii).toEqual(adminPii(1));
+      expect(ownPii).toEqual(adminPii(2));
+    });
+  });
+  it("cannot manage admin accounts without required permissions", async () => {
+    await withDb(async (db) => {
+      const admin = await insertAdmin(1, db, {
+        adminCanManageAdminAccounts: false,
+      });
+      const config = getAdminActorConfig(db);
+      const actor = new AdminActor(admin.adminId, config);
+      expect(await actor.canManageAdminAccounts()).toBe(false);
     });
   });
 });

--- a/tests/AdminActor.test.ts
+++ b/tests/AdminActor.test.ts
@@ -31,4 +31,34 @@ describe("AdminActor", () => {
       expect(await actor.canManageAdminAccounts()).toBe(false);
     });
   });
+  it("cannot manage vet accounts without required permissions", async () => {
+    await withDb(async (db) => {
+      const admin = await insertAdmin(1, db, {
+        adminCanManageVetAccounts: false,
+      });
+      const config = getAdminActorConfig(db);
+      const actor = new AdminActor(admin.adminId, config);
+      expect(await actor.canManageVetAccounts()).toBe(false);
+    });
+  });
+  it("cannot manage user accounts without required permissions", async () => {
+    await withDb(async (db) => {
+      const admin = await insertAdmin(1, db, {
+        adminCanManageUserAccounts: false,
+      });
+      const config = getAdminActorConfig(db);
+      const actor = new AdminActor(admin.adminId, config);
+      expect(await actor.canManageUserAccounts()).toBe(false);
+    });
+  });
+  it("cannot manage donors without required permissions", async () => {
+    await withDb(async (db) => {
+      const admin = await insertAdmin(1, db, {
+        adminCanManageDonors: false,
+      });
+      const config = getAdminActorConfig(db);
+      const actor = new AdminActor(admin.adminId, config);
+      expect(await actor.canManageDonors()).toBe(false);
+    });
+  });
 });

--- a/tests/AdminActorFactory.test.ts
+++ b/tests/AdminActorFactory.test.ts
@@ -1,12 +1,12 @@
 import { AdminActorFactory } from "@/lib/admin/admin-actor-factory";
 import { withDb } from "./_db_helpers";
-import { adminPii, createAdmin, getAdminActorFactoryConfig } from "./_fixtures";
+import { adminPii, insertAdmin, getAdminActorFactoryConfig } from "./_fixtures";
 
 describe("AdminActorFactory", () => {
   describe("getAdminActor", () => {
     it("should load the AdminActor for the corresponding email", async () => {
       await withDb(async (db) => {
-        const admin = await createAdmin(1, db);
+        const admin = await insertAdmin(1, db);
         const factory = new AdminActorFactory(getAdminActorFactoryConfig(db));
         const pii = adminPii(1);
         const actor = await factory.getAdminActor(pii.adminEmail);

--- a/tests/UserActor.test.ts
+++ b/tests/UserActor.test.ts
@@ -1,11 +1,11 @@
 import { withDb } from "./_db_helpers";
 import { UserActor } from "@/lib/user/user-actor";
-import { createUser, getUserActorConfig, userPii } from "./_fixtures";
+import { insertUser, getUserActorConfig, userPii } from "./_fixtures";
 
 describe("UserActor", () => {
   it("can retrieve its own actor data from the database", async () => {
     await withDb(async (db) => {
-      const user = await createUser(1, db);
+      const user = await insertUser(1, db);
       const config = getUserActorConfig(db);
       const actor = new UserActor(user.userId, config);
       const ownUser = await actor.getOwnUser();
@@ -14,7 +14,7 @@ describe("UserActor", () => {
   });
   it("can retrieve its own PII", async () => {
     await withDb(async (db) => {
-      const user = await createUser(1, db);
+      const user = await insertUser(1, db);
       const config = getUserActorConfig(db);
       const actor = new UserActor(user.userId, config);
       const ownPii = await actor.getOwnPii();

--- a/tests/UserActorFactory.test.ts
+++ b/tests/UserActorFactory.test.ts
@@ -1,12 +1,12 @@
 import { UserActorFactory } from "@/lib/user/user-actor-factory";
 import { withDb } from "./_db_helpers";
-import { userPii, createUser, getUserActorFactoryConfig } from "./_fixtures";
+import { userPii, insertUser, getUserActorFactoryConfig } from "./_fixtures";
 
 describe("UserActorFactory", () => {
   describe("getUserActor", () => {
     it("should load the UserActor for the corresponding email", async () => {
       await withDb(async (db) => {
-        const user = await createUser(1, db);
+        const user = await insertUser(1, db);
         const factory = new UserActorFactory(getUserActorFactoryConfig(db));
         const pii = userPii(1);
         const actor = await factory.getUserActor(pii.userEmail);

--- a/tests/VetActorFactory.test.ts
+++ b/tests/VetActorFactory.test.ts
@@ -1,12 +1,12 @@
 import { VetActorFactory } from "@/lib/vet/vet-actor-factory";
 import { withDb } from "./_db_helpers";
-import { createVet, getVetActorFactoryConfig, vetSpec } from "./_fixtures";
+import { insertVet, getVetActorFactoryConfig, vetSpec } from "./_fixtures";
 
 describe("VetActorFactory", () => {
   describe("getVetActor", () => {
     it("should load the VetActor for the corresponding email", async () => {
       await withDb(async (db) => {
-        const vet = await createVet(1, db);
+        const vet = await insertVet(1, db);
         const factory = new VetActorFactory(getVetActorFactoryConfig(db));
         const spec = vetSpec(1);
         const actor = await factory.getVetActor(spec.vetEmail);

--- a/tests/_fixtures.ts
+++ b/tests/_fixtures.ts
@@ -40,8 +40,14 @@ export function getAdminActorConfig(db: Pool): AdminActorConfig {
   };
 }
 
-export async function createAdmin(idx: number, db: Pool): Promise<Admin> {
-  const spec = await adminSpec(1);
+export async function insertAdmin(
+  idx: number,
+  db: Pool,
+  specOverrides?: Partial<AdminSpec>,
+): Promise<Admin> {
+  const specBase = await adminSpec(idx);
+  const spec =
+    specOverrides === undefined ? specBase : { ...specBase, ...specOverrides };
   const gen = await dbInsertAdmin(db, spec);
   const admin = await dbSelectAdmin(db, gen.adminId);
   if (admin === null) {

--- a/tests/_fixtures.ts
+++ b/tests/_fixtures.ts
@@ -103,7 +103,7 @@ export function getUserActorFactoryConfig(db: Pool): UserActorFactoryConfig {
   };
 }
 
-export async function createUser(idx: number, db: Pool): Promise<User> {
+export async function insertUser(idx: number, db: Pool): Promise<User> {
   const spec = await userSpec(1);
   const gen = await dbInsertUser(db, spec);
   const user = await dbSelectUser(db, gen.userId);
@@ -135,7 +135,7 @@ export function getVetActorFactoryConfig(dbPool: Pool): VetActorFactoryConfig {
   };
 }
 
-export async function createVet(idx: number, dbPool: Pool): Promise<Vet> {
+export async function insertVet(idx: number, dbPool: Pool): Promise<Vet> {
   const spec = vetSpec(idx);
   const gen = await dbInsertVet(dbPool, spec);
   const vet = await dbSelectVet(dbPool, gen.vetId);


### PR DESCRIPTION
Changes

(1) Methods for checking admin permissions were implemented for the AdminActor. E.g. canManageAdminAccounts

(2) The getOwnAdmin method now caches the Promise, so that calls to different canFoo canBar methods do not result in multiple database fetches.

(3) Minor refactoring. Prettier formatting, renaming createFoo to insertFoo in fixtures, and removing unused imports.