### PR TITLE
Improved Vet Options for Registration Form

### DIFF
--- a/src/app/user/registration/_lib/get-vet-options.ts
+++ b/src/app/user/registration/_lib/get-vet-options.ts
@@ -1,0 +1,18 @@
+import { dbQuery, toCamelCaseRow } from "@/lib/data/db-utils";
+import { Pool } from "pg";
+
+export type VetOption = {
+  vetId: string;
+  vetName: string;
+  vetAddress: string;
+};
+
+export async function getVetOptions(dbPool: Pool): Promise<VetOption[]> {
+  const sql = `
+    SELECT vet_id, vet_name, vet_address
+    FROM vets
+    ORDER BY vet_name
+  `;
+  const res = await dbQuery(dbPool, sql, []);
+  return res.rows.map(toCamelCaseRow) as VetOption[];
+}

--- a/src/components/bark/bark-form.tsx
+++ b/src/components/bark/bark-form.tsx
@@ -201,6 +201,7 @@ export function BarkFormSingleCheckbox(props: {
 export type BarkFormOption = {
   value: string;
   label: string;
+  description?: string;
 };
 
 export function BarkFormRadioGroup(props: {
@@ -249,14 +250,19 @@ export function BarkFormRadioGroup(props: {
                 {options.map((option) => (
                   <FormItem
                     key={option.value}
-                    className="flex items-center space-x-3 space-y-0"
+                    className="flex items-start space-x-3 space-y-0"
                   >
                     <FormControl>
                       <RadioGroupItem value={option.value} />
                     </FormControl>
-                    <FormLabel className="font-normal">
-                      {option.label}
-                    </FormLabel>
+                    <div>
+                      <FormLabel className="font-normal">
+                        {option.label}
+                      </FormLabel>
+                      {!!option.description && (
+                        <FormDescription>{option.description}</FormDescription>
+                      )}
+                    </div>
                   </FormItem>
                 ))}
               </RadioGroup>

--- a/tests/_fixtures.ts
+++ b/tests/_fixtures.ts
@@ -220,13 +220,14 @@ export async function insertVet(idx: number, dbPool: Pool): Promise<Vet> {
   return vet;
 }
 
-export function getVetSpec(idx: number): VetSpec {
-  return {
+export function getVetSpec(idx: number, overrides?: Partial<VetSpec>): VetSpec {
+  const base: VetSpec = {
     vetName: `Vet ${idx}`,
     vetEmail: `vet${idx}@vet.com`,
     vetPhoneNumber: `+65 ${6000000 + idx}`,
     vetAddress: `${100 + idx} Dog Park Drive`,
   };
+  return { ...base, ...overrides };
 }
 
 export function someEmail(idx: number): string {

--- a/tests/get-vet-options.test.ts
+++ b/tests/get-vet-options.test.ts
@@ -1,0 +1,44 @@
+import {
+  VetOption,
+  getVetOptions,
+} from "@/app/user/registration/_lib/get-vet-options";
+import { withDb } from "./_db_helpers";
+import { getVetSpec } from "./_fixtures";
+import { dbInsertVet } from "@/lib/data/db-vets";
+
+describe("getVetOptions", () => {
+  it("should return an empty list when there are no vets in the database", async () => {
+    await withDb(async (dbPool) => {
+      const options: VetOption[] = await getVetOptions(dbPool);
+      expect(options).toEqual([]);
+    });
+  });
+  it("should return vet options in order of vet name", async () => {
+    await withDb(async (dbPool) => {
+      const spec1 = getVetSpec(1, {
+        vetName: "Roban Pet House",
+        vetAddress: "56 Towns Rd, Singapore 555111",
+      });
+      const spec2 = getVetSpec(2, {
+        vetName: "Aero Vet",
+        vetAddress: "81 Airport Drive, Singapore 991199",
+      });
+      const gen1 = await dbInsertVet(dbPool, spec1);
+      const gen2 = await dbInsertVet(dbPool, spec2);
+      const options: VetOption[] = await getVetOptions(dbPool);
+      const expected: VetOption[] = [
+        {
+          vetId: gen2.vetId,
+          vetName: spec2.vetName,
+          vetAddress: spec2.vetAddress,
+        },
+        {
+          vetId: gen1.vetId,
+          vetName: spec1.vetName,
+          vetAddress: spec1.vetAddress,
+        },
+      ];
+      expect(options).toEqual(expected);
+    });
+  });
+});


### PR DESCRIPTION
(1) Feature - Vet addresses are now rendered below the vet name. The BarkFormOption type was extended to include an optional `description` to support this. When `description` is specified, a FormDescription is rendered below the FormLabel. Currently this only works for radio groups.

(2) Testing - The function for querying the database is moved into ./_lib/get-vet-options so its getVetOptions function can be tested.

(3) Refactoring - The manner by which the async retrievals for breed list and vet options are orchestrated is improved.