### PR TITLE
More fields for my dog details

### DIFF
--- a/src/lib/data/db-dogs.ts
+++ b/src/lib/data/db-dogs.ts
@@ -1,5 +1,6 @@
 import { DbContext, dbQuery, toCamelCaseRow } from "./db-utils";
 import { DogRecord, DogGen, DogSpec } from "./db-models";
+import { ParticipationStatus } from "./db-enums";
 
 const DOG_COLUMNS = [
   "dog_id",
@@ -132,4 +133,26 @@ export async function dbSelectPreferredVetIds(
   `;
   const res = await dbQuery(ctx, sql, [dogId]);
   return res.rows.map((row) => row.vet_id);
+}
+
+export async function dbUpdateDogParticipation(
+  dbCtx: DbContext,
+  dogId: string,
+  participationStatus: ParticipationStatus,
+  pauseExpiryTime?: Date,
+): Promise<boolean> {
+  const sql = `
+  UPDATE dogs
+  SET
+    dog_participation_status = $2,
+    dog_pause_expiry_time = $3
+  WHERE dog_id = $1
+  RETURNING 1
+  `;
+  const res = await dbQuery(dbCtx, sql, [
+    dogId,
+    participationStatus,
+    pauseExpiryTime ?? null,
+  ]);
+  return res.rows.length === 1;
 }

--- a/src/lib/user/user-models.ts
+++ b/src/lib/user/user-models.ts
@@ -44,6 +44,10 @@ export type MyDogDetails = StatusSet & {
   dogDea1Point1: DogAntigenPresence;
   dogEverPregnant: YesNoUnknown;
   dogEverReceivedTransfusion: YesNoUnknown;
+  dogPreferredVetId: string | null;
+  dogParticipationStatus: ParticipationStatus;
+  // TODO: dogPauseEndReason: string; When the schema supports it
+  dogPauseExpiryTime: Date | null;
 
   dogReports: MyDogReport[];
 };

--- a/tests/_fixtures.ts
+++ b/tests/_fixtures.ts
@@ -44,7 +44,7 @@ import { VetMapper } from "@/lib/data/vet-mapper";
 import { DogMapper } from "@/lib/data/dog-mapper";
 import { UserMapper } from "@/lib/data/user-mapper";
 import { BARK_UTC } from "@/lib/utilities/bark-time";
-import { DbContext, dbQuery } from "@/lib/data/db-utils";
+import { DbContext } from "@/lib/data/db-utils";
 import { dbInsertDog } from "@/lib/data/db-dogs";
 import { OtpService } from "@/lib/services/otp";
 import { UserActor, UserActorConfig } from "@/lib/user/user-actor";

--- a/tests/user/get-my-dog-details.test.ts
+++ b/tests/user/get-my-dog-details.test.ts
@@ -26,7 +26,7 @@ import {
   SINGAPORE_TIME_ZONE,
   parseDateTime,
 } from "@/lib/utilities/bark-time";
-import { MILLIS_PER_WEEK } from "@/lib/utilities/bark-millis";
+import { MILLIS_PER_DAY, MILLIS_PER_WEEK } from "@/lib/utilities/bark-millis";
 
 describe("getMyDogDetails", () => {
   it("should return null when user does not own the dog requested", async () => {
@@ -54,8 +54,10 @@ describe("getMyDogDetails", () => {
       const v1 = await insertVet(1, dbPool);
       await dbInsertDogVetPreference(dbPool, d1.dogId, v1.vetId);
 
-      // and participation is paused for two weeks.
-      const pauseExpiryTime = new Date(Date.now() + 2 * MILLIS_PER_WEEK);
+      // and participation has a pause that expired yesterday (so the expected
+      // participation status returned should be PARTICIPATING and the pause
+      // expiry time should be null despite these values)
+      const pauseExpiryTime = new Date(Date.now() - MILLIS_PER_DAY);
       await dbUpdateDogParticipation(
         dbPool,
         d1.dogId,
@@ -76,7 +78,7 @@ describe("getMyDogDetails", () => {
         serviceStatus: "AVAILABLE",
         profileStatus: "COMPLETE",
         medicalStatus: "TEMPORARILY_INELIGIBLE",
-        participationStatus: "PAUSED",
+        participationStatus: "PARTICIPATING",
         numPendingReports: 0,
 
         dogName: oii.dogName,
@@ -89,8 +91,8 @@ describe("getMyDogDetails", () => {
         dogEverReceivedTransfusion: spec.dogEverReceivedTransfusion,
 
         dogPreferredVetId: v1.vetId,
-        dogParticipationStatus: "PAUSED",
-        dogPauseExpiryTime: pauseExpiryTime,
+        dogParticipationStatus: "PARTICIPATING",
+        dogPauseExpiryTime: null,
 
         dogReports: [],
       });

--- a/tests/user/get-my-dog-details.test.ts
+++ b/tests/user/get-my-dog-details.test.ts
@@ -26,7 +26,7 @@ import {
   SINGAPORE_TIME_ZONE,
   parseDateTime,
 } from "@/lib/utilities/bark-time";
-import { MILLIS_PER_DAY, MILLIS_PER_WEEK } from "@/lib/utilities/bark-millis";
+import { MILLIS_PER_DAY } from "@/lib/utilities/bark-millis";
 
 describe("getMyDogDetails", () => {
   it("should return null when user does not own the dog requested", async () => {

--- a/tests/user/get-my-dog-details.test.ts
+++ b/tests/user/get-my-dog-details.test.ts
@@ -41,19 +41,23 @@ describe("getMyDogDetails", () => {
   });
   it("should return dog details when user owns the dog requested", async () => {
     await withDb(async (dbPool) => {
-      // Given that user1 owns dog1
-      const { userId: userId1 } = await insertUser(1, dbPool);
-      const { dogId: dogId1 } = await insertDog(1, userId1, dbPool);
+      // Given that u1 owns dog d1
+      const u1 = await insertUser(1, dbPool);
+      const d1 = await insertDog(1, u1.userId, dbPool);
+
+      // and the preferred vet is v1
+      const v1 = await insertVet(1, dbPool);
+      await dbInsertDogVetPreference(dbPool, d1.dogId, v1.vetId);
 
       // When user1 requests for details pertaining to dog1
-      const actor1 = getUserActor(dbPool, userId1);
-      const dogDetails = await getMyDogDetails(actor1, dogId1);
+      const actor = getUserActor(dbPool, u1.userId);
+      const dogDetails = await getMyDogDetails(actor, d1.dogId);
 
       // Then dog details should be returned
       const spec = await getDogSpec(1);
       const oii = await getDogOii(1);
       expect(dogDetails).toEqual({
-        dogId: dogId1,
+        dogId: d1.dogId,
 
         serviceStatus: "AVAILABLE",
         profileStatus: "COMPLETE",
@@ -69,6 +73,10 @@ describe("getMyDogDetails", () => {
         dogDea1Point1: spec.dogDea1Point1,
         dogEverPregnant: spec.dogEverPregnant,
         dogEverReceivedTransfusion: spec.dogEverReceivedTransfusion,
+
+        dogPreferredVetId: v1.vetId,
+        dogParticipationStatus: "PARTICIPATING",
+        dogPauseExpiryTime: null,
 
         dogReports: [],
       });


### PR DESCRIPTION
Extend the MyDogDetails object returned by getMyDogDetails to include the following fields:

* dogParticipationStatus
* dogPauseExpiryTime
* dogPreferredVetId

These are to support the form pre-fill needs of the /user/my-pet/dogs/[dogId]/edit page.
