### PR TITLE
Dog Cards, Nav Bar, and Side Bar

### DIFF
--- a/e2e/user-my-pets.spec.ts
+++ b/e2e/user-my-pets.spec.ts
@@ -24,5 +24,8 @@ test.describe("user my pets", () => {
         .filter({ hasText: "PerryIneligiblePerry does not" })
         .nth(3),
     ).toBeVisible();
+    await expect(
+      page.locator("div").filter({ hasText: "BentleyProfile" }).nth(3),
+    ).toBeVisible();
   });
 });

--- a/scripts/setup-dev-data.js
+++ b/scripts/setup-dev-data.js
@@ -381,6 +381,19 @@ function getDogFields(idx, overrides) {
 const MILLIS_PER_YEAR = 365 * 86400 * 1000;
 const MILLIS_PER_MONTH = MILLIS_PER_YEAR / 12;
 
+function getIncompleteDogOverrides() {
+  return {
+    dogName: "Bentley",
+    dogBreed: "",
+    dogBirthday: formatBirthday(new Date(Date.now() - 3 * MILLIS_PER_YEAR)),
+    dogGender: "MALE",
+    dogWeightKg: null,
+    dogDea1Point1: "UNKNOWN",
+    dogEverPregnant: "UNKNOWN",
+    dogEverReceivedTransfusion: "UNKNOWN",
+  };
+}
+
 function getEligibleDogOverrides() {
   return {
     dogName: "Mape",
@@ -589,6 +602,7 @@ function deleteData() {
 
 function createUiTestUserAccount() {
   const toCreate = [
+    getIncompleteDogOverrides(),
     getEligibleDogOverrides(),
     getIneligibleDogOverrides(),
     getPermanentlyIneligibleDogOverrides(),

--- a/src/app/_components/header-items.tsx
+++ b/src/app/_components/header-items.tsx
@@ -14,19 +14,10 @@ const MobileNav = ({ accountType }: { accountType?: AccountType }) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
   return (
-    <nav className="sticky top-0 z-10 flex min-h-[72px] flex-row items-center justify-between border-b bg-white shadow-lg">
+    <nav className="sticky top-0 z-10 border-b bg-white shadow-lg">
       <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
-        <div className="mx-4 flex min-h-[72px] items-center gap-2">
-          <Collapsible.Trigger asChild>
-            <Button variant="outline" size="icon" className="md:hidden">
-              {isOpen ? (
-                <XIcon className="h-4 w-4" />
-              ) : (
-                <MenuIcon className="h-4 w-4" />
-              )}
-            </Button>
-          </Collapsible.Trigger>
-          <Link href={RoutePath.ROOT}>
+        <div className="mx-3 flex min-h-[72px] flex-row items-center justify-between">
+          <Link href={RoutePath.ROOT} className="w-[60px]">
             <Image
               src={IMG_PATH.BARK_BANK_LOGO}
               alt="bark bank logo"
@@ -34,6 +25,15 @@ const MobileNav = ({ accountType }: { accountType?: AccountType }) => {
               height={60}
             />
           </Link>
+          <Collapsible.Trigger asChild>
+            <Button variant="outline" size="icon">
+              {isOpen ? (
+                <XIcon className="h-4 w-4" />
+              ) : (
+                <MenuIcon className="h-4 w-4" />
+              )}
+            </Button>
+          </Collapsible.Trigger>
         </div>
 
         <Collapsible.Content>

--- a/src/app/_components/header-items.tsx
+++ b/src/app/_components/header-items.tsx
@@ -10,13 +10,13 @@ import { Button } from "@/components/ui/button";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { AccountType } from "@/lib/auth-models";
 
-const HeaderItems = ({ accountType }: { accountType?: AccountType }) => {
+const MobileNav = ({ accountType }: { accountType?: AccountType }) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
   return (
-    <nav className="sticky top-0 z-10 flex min-h-[72px] items-center justify-between border-b bg-white shadow-lg">
+    <nav className="sticky top-0 z-10 flex min-h-[72px] flex-row items-center justify-between border-b bg-white shadow-lg">
       <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
-        <div className="mx-4 flex min-h-[72px] items-center gap-2 md:mx-10">
+        <div className="mx-4 flex min-h-[72px] items-center gap-2">
           <Collapsible.Trigger asChild>
             <Button variant="outline" size="icon" className="md:hidden">
               {isOpen ? (
@@ -26,7 +26,6 @@ const HeaderItems = ({ accountType }: { accountType?: AccountType }) => {
               )}
             </Button>
           </Collapsible.Trigger>
-
           <Link href={RoutePath.ROOT}>
             <Image
               src={IMG_PATH.BARK_BANK_LOGO}
@@ -38,7 +37,7 @@ const HeaderItems = ({ accountType }: { accountType?: AccountType }) => {
         </div>
 
         <Collapsible.Content>
-          <div className="mx-4 my-2 flex flex-col gap-2 md:hidden">
+          <div className="mx-4 my-2 flex flex-col gap-2">
             <Link href={RoutePath.ROOT}>Home</Link>
             <Link href={RoutePath.ABOUT_US}>About Us</Link>
             <Link href={RoutePath.BE_A_DONOR}>Be a Donor</Link>
@@ -51,8 +50,25 @@ const HeaderItems = ({ accountType }: { accountType?: AccountType }) => {
           </div>
         </Collapsible.Content>
       </Collapsible.Root>
+    </nav>
+  );
+};
 
-      <div className="hidden gap-x-8 md:flex md:last:mr-8">
+const DesktopNav = ({ accountType }: { accountType?: AccountType }) => {
+  return (
+    <nav className="sticky top-0 z-10 flex h-[72px] flex-row items-center justify-between border-b bg-white shadow-lg">
+      <div className="ml-8 w-[72px] flex-none">
+        <Link href={RoutePath.ROOT}>
+          <Image
+            src={IMG_PATH.BARK_BANK_LOGO}
+            alt="bark bank logo"
+            width={60}
+            height={60}
+          />
+        </Link>
+      </div>
+
+      <div className="mr-8 flex gap-8 gap-x-8">
         <Link href={RoutePath.ROOT}>Home</Link>
         <Link href={RoutePath.ABOUT_US}>About Us</Link>
         <Link href={RoutePath.BE_A_DONOR}>Be a Donor</Link>
@@ -64,6 +80,19 @@ const HeaderItems = ({ accountType }: { accountType?: AccountType }) => {
         </Link>
       </div>
     </nav>
+  );
+};
+
+const HeaderItems = ({ accountType }: { accountType?: AccountType }) => {
+  return (
+    <>
+      <div className="md:hidden">
+        <MobileNav />
+      </div>
+      <div className="hidden md:block">
+        <DesktopNav />
+      </div>
+    </>
   );
 };
 

--- a/src/app/_components/header-items.tsx
+++ b/src/app/_components/header-items.tsx
@@ -38,13 +38,28 @@ const MobileNav = ({ accountType }: { accountType?: AccountType }) => {
 
         <Collapsible.Content>
           <div className="mx-4 my-2 flex flex-col gap-2">
-            <Link href={RoutePath.ROOT}>Home</Link>
-            <Link href={RoutePath.ABOUT_US}>About Us</Link>
-            <Link href={RoutePath.BE_A_DONOR}>Be a Donor</Link>
-            <Link href={RoutePath.ARTICLES}>Articles</Link>
-            <Link href={RoutePath.FAQ}>FAQ</Link>
-            <Link href={RoutePath.INFO}>Info</Link>
-            <Link href={RoutePath.ACCOUNT_DASHBOARD(accountType)}>
+            <Link className="text-right" href={RoutePath.ROOT}>
+              Home
+            </Link>
+            <Link className="text-right" href={RoutePath.ABOUT_US}>
+              About Us
+            </Link>
+            <Link className="text-right" href={RoutePath.BE_A_DONOR}>
+              Be a Donor
+            </Link>
+            <Link className="text-right" href={RoutePath.ARTICLES}>
+              Articles
+            </Link>
+            <Link className="text-right" href={RoutePath.FAQ}>
+              FAQ
+            </Link>
+            <Link className="text-right" href={RoutePath.INFO}>
+              Info
+            </Link>
+            <Link
+              className="flex flex-row-reverse"
+              href={RoutePath.ACCOUNT_DASHBOARD(accountType)}
+            >
               <CircleUser />
             </Link>
           </div>

--- a/src/app/_components/header-items.tsx
+++ b/src/app/_components/header-items.tsx
@@ -14,7 +14,7 @@ const MobileNav = ({ accountType }: { accountType?: AccountType }) => {
   const [isOpen, setIsOpen] = React.useState(false);
 
   return (
-    <nav className="sticky top-0 z-10 border-b bg-white shadow-lg">
+    <nav className="border-b bg-white shadow-lg">
       <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
         <div className="mx-3 flex min-h-[72px] flex-row items-center justify-between">
           <Link href={RoutePath.ROOT} className="w-[60px]">
@@ -56,7 +56,7 @@ const MobileNav = ({ accountType }: { accountType?: AccountType }) => {
 
 const DesktopNav = ({ accountType }: { accountType?: AccountType }) => {
   return (
-    <nav className="sticky top-0 z-10 flex h-[72px] flex-row items-center justify-between border-b bg-white shadow-lg">
+    <nav className="flex h-[72px] flex-row items-center justify-between border-b bg-white shadow-lg">
       <div className="ml-8 w-[72px] flex-none">
         <Link href={RoutePath.ROOT}>
           <Image
@@ -85,14 +85,14 @@ const DesktopNav = ({ accountType }: { accountType?: AccountType }) => {
 
 const HeaderItems = ({ accountType }: { accountType?: AccountType }) => {
   return (
-    <>
+    <div className="sticky top-0 z-10">
       <div className="md:hidden">
         <MobileNav />
       </div>
       <div className="hidden md:block">
         <DesktopNav />
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/app/user/(logged-in)/my-pets/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/page.tsx
@@ -194,7 +194,7 @@ function ActionBlock(props: { dog: MyDog }) {
     );
   }
   return (
-    <div className="flex w-full flex-col gap-3">
+    <div className="flex flex-col gap-3">
       <Button variant="brandInverse" className="w-full">
         Edit
       </Button>
@@ -213,7 +213,7 @@ function DogCard(props: { dog: MyDog; cardIdx: number; isLastCard: boolean }) {
       : IMG_PATH.BORDER_COLLIE_DOG_AVATAR;
   return (
     <>
-      <div className="mt-3 flex flex-col place-items-center gap-3 rounded-md px-3 py-3 shadow-sm shadow-slate-400 first:mt-0">
+      <div className="mt-3 flex flex-col place-items-center gap-3 rounded-md px-3 py-3 shadow-sm shadow-slate-400 first:mt-0 md:flex-row">
         {/* Avatar */}
         <Image
           src={imgSrc}
@@ -224,7 +224,7 @@ function DogCard(props: { dog: MyDog; cardIdx: number; isLastCard: boolean }) {
         />
 
         {/* Details */}
-        <div>
+        <div className="flex-1">
           <div className="text-grey-100 text-lg font-semibold leading-9">
             {dog.dogName}
           </div>
@@ -232,7 +232,9 @@ function DogCard(props: { dog: MyDog; cardIdx: number; isLastCard: boolean }) {
         </div>
 
         {/* Buttons */}
-        <ActionBlock dog={dog} />
+        <div className="w-full md:w-48">
+          <ActionBlock dog={dog} />
+        </div>
       </div>
     </>
   );

--- a/src/app/user/(logged-in)/my-pets/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/page.tsx
@@ -31,7 +31,6 @@ import {
   StatusSet,
   mapStatusSetToHighlightedStatus,
 } from "@/lib/data/status-mapper";
-import { BarkH1, BarkH3, BarkH5 } from "@/components/bark/bark-typography";
 
 function toStatusSet(dog: MyDog): StatusSet {
   const statusSet: StatusSet = {
@@ -214,7 +213,7 @@ function DogCard(props: { dog: MyDog; cardIdx: number; isLastCard: boolean }) {
       : IMG_PATH.BORDER_COLLIE_DOG_AVATAR;
   return (
     <>
-      <div className="mt-3 flex flex-col place-items-center gap-3 rounded-md px-3 py-3 shadow-sm shadow-slate-400">
+      <div className="mt-3 flex flex-col place-items-center gap-3 rounded-md px-3 py-3 shadow-sm shadow-slate-400 first:mt-0">
         {/* Avatar */}
         <Image
           src={imgSrc}

--- a/src/app/user/(logged-in)/my-pets/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/page.tsx
@@ -31,6 +31,7 @@ import {
   StatusSet,
   mapStatusSetToHighlightedStatus,
 } from "@/lib/data/status-mapper";
+import { BarkH1, BarkH3, BarkH5 } from "@/components/bark/bark-typography";
 
 function toStatusSet(dog: MyDog): StatusSet {
   const statusSet: StatusSet = {
@@ -188,15 +189,19 @@ function ActionBlock(props: { dog: MyDog }) {
   const highlightedStatus = mapStatusSetToHighlightedStatus(toStatusSet(dog));
   if (highlightedStatus === PROFILE_STATUS.INCOMPLETE) {
     return (
-      <div className="flex flex-row gap-3">
-        <Button variant="brand">Complete Profile</Button>
-      </div>
+      <Button variant="brand" className="w-full">
+        Complete Profile
+      </Button>
     );
   }
   return (
-    <div className="flex flex-row gap-3">
-      <Button variant="brandInverse">Edit</Button>
-      <Button variant="brandInverse">View</Button>
+    <div className="flex w-full flex-col gap-3">
+      <Button variant="brandInverse" className="w-full">
+        Edit
+      </Button>
+      <Button variant="brandInverse" className="w-full">
+        View
+      </Button>
     </div>
   );
 }
@@ -209,47 +214,26 @@ function DogCard(props: { dog: MyDog; cardIdx: number; isLastCard: boolean }) {
       : IMG_PATH.BORDER_COLLIE_DOG_AVATAR;
   return (
     <>
-      <div
-        className={clsx("mt-4 flex flex-row gap-5 pb-4 md:mx-5 md:px-4", {
-          "border-b border-solid border-[#A5A4A6]": !isLastCard,
-        })}
-      >
-        {/* Left Side Avatar */}
+      <div className="mt-3 flex flex-col place-items-center gap-3 rounded-md px-3 py-3 shadow-sm shadow-slate-400">
+        {/* Avatar */}
         <Image
           src={imgSrc}
           alt="Generic dog avatar for dog details"
           width={100}
           height={100}
-          className="hidden md:block"
+          className=""
         />
 
-        {/* Right Side Details */}
+        {/* Details */}
         <div>
-          {/* Dog Name across the details */}
-          <div>
-            <Image
-              src={imgSrc}
-              alt="Generic dog avatar for dog details"
-              width={100}
-              height={100}
-              className="md:hidden"
-            />
-            <div className="text-grey-100 text-lg font-bold leading-9">
-              {dog.dogName}
-            </div>
+          <div className="text-grey-100 text-lg font-semibold leading-9">
+            {dog.dogName}
           </div>
-
-          {/* Details and Buttons below */}
-          <div className="mt-2 flex flex-col gap-5 md:flex-row">
-            <div className="min-w-40 max-w-96">
-              <StatusBlock dog={dog} />
-            </div>
-
-            <div>
-              <ActionBlock dog={dog} />
-            </div>
-          </div>
+          <StatusBlock dog={dog} />
         </div>
+
+        {/* Buttons */}
+        <ActionBlock dog={dog} />
       </div>
     </>
   );
@@ -273,7 +257,7 @@ export default async function Page() {
           />
         ))}
       </div>
-      <Button className="w-full" variant="brandInverse">
+      <Button className="mt-3 w-full" variant="brandInverse">
         Add Pet
       </Button>
     </>

--- a/src/components/bark/bark-sidebar.tsx
+++ b/src/components/bark/bark-sidebar.tsx
@@ -27,7 +27,7 @@ function SideOption(props: { route: BarkSidebarRoute; currentPath: string }) {
     <Link href={route.href}>
       <div
         className={clsx(
-          "flex w-[58px] flex-col items-center justify-center gap-[7px] rounded-[20px] px-[16px] py-[16px] lg:w-[200px] lg:px-[20px]",
+          "flex w-[58px] flex-col items-center justify-center gap-[7px] rounded-[20px] px-[16px] py-[16px] md:w-[200px] md:px-[20px]",
           {
             "bg-brand text-brand-white": !isActive,
             "bg-brand-white text-brand": isActive,
@@ -40,11 +40,11 @@ function SideOption(props: { route: BarkSidebarRoute; currentPath: string }) {
           alt={`Icon for the ${route.label} option`}
           width={30}
           height={30}
-          className="h-[24px] w-[24px] lg:h-[30px] lg:w-[30px]"
+          className="h-[24px] w-[24px] md:h-[30px] md:w-[30px]"
         />
 
         {/* Label */}
-        <div className="hidden w-full text-center text-[14px] font-[700] leading-[20px] lg:block">
+        <div className="hidden w-full text-center text-[14px] font-[700] leading-[20px] md:block">
           {route.label}
         </div>
       </div>
@@ -60,7 +60,7 @@ export function BarkSidebarLayout(props: {
   return (
     <div className="flex flex-row">
       {/* Sidebar */}
-      <div className="flex min-h-screen w-[78px] flex-col items-center bg-brand px-[10px] py-[12px] lg:w-[220px]">
+      <div className="flex min-h-screen w-[78px] flex-col items-center bg-brand px-[10px] py-[12px] md:w-[220px]">
         {props.routes.map((route) => {
           return (
             <SideOption

--- a/src/components/bark/bark-sidebar.tsx
+++ b/src/components/bark/bark-sidebar.tsx
@@ -73,7 +73,7 @@ export function BarkSidebarLayout(props: {
       </div>
 
       {/* Content */}
-      <div className="w-full flex-1 px-[12px] py-[20px] md:px-[40px]">
+      <div className="w-full flex-1 px-3 py-3 md:px-[40px]">
         {props.children}
       </div>
     </div>


### PR DESCRIPTION
Changes for my-pets

- use rounded cards for each pet in the my-pets list
- update the layout for mobile and desktop

Changes for sidebar

- adjust breakpoint to md. This makes it consistent with itself and with the nav bar.

Changes for nav bar

- split the mobile and desktop variants into two different sub-components
- move hamburger menu to right side for mobile variant.

In aggregate, this fixes the problem where sometimes the nav bar is shorter than the content.

<img width="425" alt="image" src="https://github.com/barkbank/barkbank-pawtal/assets/2757078/0e54a303-285d-4ef9-bfa4-b39cf93c7f38">
