### PR TITLE
Revised Navigation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,12 +82,12 @@ reset-local-database:
 # branch.
 .PHONY: wip
 wip:
-	grep --color=always -R WIP src tests db
+	grep --color=always -R WIP src tests db e2e
 
 # Lists TODO notes.
 .PHONY: todo
 todo:
-	grep --color=always -R TODO src tests db
+	grep --color=always -R TODO src tests db e2e
 
 # Diff local schema and barkbank-schemas
 .PHONY: schema-diff

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ test:
 # fails.
 .PHONY: test-ui
 test-ui: playwright-browsers
-	npx playwright test
+	npx playwright test --project "Mobile Chrome" --project "chromium"
 
 # Run playwright tests in headed mode, you will see flashes of
 # browser screens.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 # Default command. It installs npm packages, if any, runs the code
-# formatter, and then runs the unit tests.
+# formatter, runs the unit tests, and does a schema diff.
 .PHONY: default
 default: npm-install fmt test schema-diff
+
+# Does everything default does AND THEN also run frontend tests—which
+# takes awhile to complete. If you just want to run the frontend
+# tests, use test-ui.
+.PHONY: all
+all: default test-ui
 
 # Vars
 BARKBANK_SCHEMA_DIR=../barkbank-schema

--- a/e2e/_ui_test_helpers.ts
+++ b/e2e/_ui_test_helpers.ts
@@ -5,22 +5,6 @@ export function urlOf(path: string): string {
   return `http://localhost:3000${path}`;
 }
 
-// WIP: Remove UI_URLS
-export const UI_URLS = {
-  ROOT: urlOf(RoutePath.ROOT),
-  LOGOUT_PAGE: urlOf(RoutePath.LOGOUT_PAGE),
-
-  USER_LOGGED_IN_PAGE: urlOf(RoutePath.USER_DEFAULT_LOGGED_IN_PAGE),
-  USER_LOGIN: urlOf(RoutePath.USER_LOGIN_PAGE),
-  USER_MY_PETS: urlOf(RoutePath.USER_MY_PETS),
-  USER_MY_ACCOUNT: urlOf(RoutePath.USER_MY_ACCOUNT_PAGE),
-
-  VET_LOGIN: urlOf(RoutePath.VET_LOGIN_PAGE),
-
-  EXTERNAL_FAQ_PAGE: RoutePath.VISIT_FAQ,
-  EXTERNAL_WEBSITE_PAGE: RoutePath.VISIT_WEBSITE,
-} as const;
-
 export const UI_LOCATOR = {
   NAV_BAR: "#bark-nav-bar",
   NAV_MENU_BUTTON: "#bark-nav-menu-button",

--- a/e2e/_ui_test_helpers.ts
+++ b/e2e/_ui_test_helpers.ts
@@ -1,10 +1,25 @@
+import { RoutePath } from "@/lib/route-path";
 import { expect, Page } from "@playwright/test";
 
+function getLocalUrl(path: string): string {
+  return `http://localhost:3000${path}`;
+}
+
 export const UI_URLS = {
-  USER_LOGIN: "http://localhost:3000/user/login",
-  USER_MY_PETS: "http://localhost:3000/user/my-pets",
-  USER_MY_ACCOUNT: "http://localhost:3000/user/my-account",
-  ROOT: "http://localhost:3000/",
+  ROOT: getLocalUrl(RoutePath.ROOT),
+  LOGOUT_PAGE: getLocalUrl(RoutePath.LOGOUT_PAGE),
+
+  USER_LOGIN: getLocalUrl(RoutePath.USER_LOGIN_PAGE),
+  USER_MY_PETS: getLocalUrl(RoutePath.USER_MY_PETS),
+  USER_MY_ACCOUNT: getLocalUrl(RoutePath.USER_MY_ACCOUNT_PAGE),
+
+  EXTERNAL_FAQ_PAGE: RoutePath.VISIT_FAQ,
+  EXTERNAL_WEBSITE_PAGE: RoutePath.VISIT_WEBSITE,
+} as const;
+
+export const UI_LOCATOR = {
+  NAV_BAR: "#nav-bar",
+  NAV_MENU_BUTTON: "#nav-menu-button",
 } as const;
 
 export const UI_USER = {

--- a/e2e/_ui_test_helpers.ts
+++ b/e2e/_ui_test_helpers.ts
@@ -9,6 +9,7 @@ export const UI_URLS = {
   ROOT: getLocalUrl(RoutePath.ROOT),
   LOGOUT_PAGE: getLocalUrl(RoutePath.LOGOUT_PAGE),
 
+  USER_LOGGED_IN_PAGE: getLocalUrl(RoutePath.USER_DEFAULT_LOGGED_IN_PAGE),
   USER_LOGIN: getLocalUrl(RoutePath.USER_LOGIN_PAGE),
   USER_MY_PETS: getLocalUrl(RoutePath.USER_MY_PETS),
   USER_MY_ACCOUNT: getLocalUrl(RoutePath.USER_MY_ACCOUNT_PAGE),
@@ -20,6 +21,7 @@ export const UI_URLS = {
 export const UI_LOCATOR = {
   NAV_BAR: "#nav-bar",
   NAV_MENU_BUTTON: "#nav-menu-button",
+  SIDEBAR: "#sidebar",
 } as const;
 
 export const UI_USER = {
@@ -39,5 +41,5 @@ export async function loginTestUser(args: { page: Page }) {
   await expect(page.getByText(UI_USER.USER_EMAIL)).toBeVisible();
   await page.getByLabel("Enter OTP").fill("000000");
   await page.getByRole("button", { name: "Login" }).click();
-  await expect(page).toHaveURL(UI_URLS.USER_MY_PETS);
+  await expect(page).toHaveURL(UI_URLS.USER_LOGGED_IN_PAGE);
 }

--- a/e2e/_ui_test_helpers.ts
+++ b/e2e/_ui_test_helpers.ts
@@ -1,18 +1,21 @@
 import { RoutePath } from "@/lib/route-path";
 import { expect, Page } from "@playwright/test";
 
-function getLocalUrl(path: string): string {
+export function urlOf(path: string): string {
   return `http://localhost:3000${path}`;
 }
 
+// WIP: Remove UI_URLS
 export const UI_URLS = {
-  ROOT: getLocalUrl(RoutePath.ROOT),
-  LOGOUT_PAGE: getLocalUrl(RoutePath.LOGOUT_PAGE),
+  ROOT: urlOf(RoutePath.ROOT),
+  LOGOUT_PAGE: urlOf(RoutePath.LOGOUT_PAGE),
 
-  USER_LOGGED_IN_PAGE: getLocalUrl(RoutePath.USER_DEFAULT_LOGGED_IN_PAGE),
-  USER_LOGIN: getLocalUrl(RoutePath.USER_LOGIN_PAGE),
-  USER_MY_PETS: getLocalUrl(RoutePath.USER_MY_PETS),
-  USER_MY_ACCOUNT: getLocalUrl(RoutePath.USER_MY_ACCOUNT_PAGE),
+  USER_LOGGED_IN_PAGE: urlOf(RoutePath.USER_DEFAULT_LOGGED_IN_PAGE),
+  USER_LOGIN: urlOf(RoutePath.USER_LOGIN_PAGE),
+  USER_MY_PETS: urlOf(RoutePath.USER_MY_PETS),
+  USER_MY_ACCOUNT: urlOf(RoutePath.USER_MY_ACCOUNT_PAGE),
+
+  VET_LOGIN: urlOf(RoutePath.VET_LOGIN_PAGE),
 
   EXTERNAL_FAQ_PAGE: RoutePath.VISIT_FAQ,
   EXTERNAL_WEBSITE_PAGE: RoutePath.VISIT_WEBSITE,
@@ -34,13 +37,43 @@ export const UI_USER = {
   PERMANENTLY_INELIGIBLE_DOG_NAME: "Perry",
 } as const;
 
+export const UI_VET = {
+  VET_EMAIL: "vet1@vet.com",
+};
+
+export const UI_ADMIN = {
+  ADMIN_EMAIL: "admin1@admin.com",
+};
+
 export async function loginTestUser(args: { page: Page }) {
   const { page } = args;
-  await page.goto(UI_URLS.USER_LOGIN);
+  await page.goto(urlOf(RoutePath.USER_LOGIN_PAGE));
   await page.getByLabel("Please provide your email").fill(UI_USER.USER_EMAIL);
   await page.getByRole("button", { name: "Send me an OTP" }).click();
   await expect(page.getByText(UI_USER.USER_EMAIL)).toBeVisible();
   await page.getByLabel("Enter OTP").fill("000000");
   await page.getByRole("button", { name: "Login" }).click();
-  await expect(page).toHaveURL(UI_URLS.USER_LOGGED_IN_PAGE);
+  await expect(page).toHaveURL(urlOf(RoutePath.USER_DEFAULT_LOGGED_IN_PAGE));
+}
+
+export async function loginTestVet(args: { page: Page }) {
+  const { page } = args;
+  await page.goto(urlOf(RoutePath.VET_LOGIN_PAGE));
+  await page.getByLabel("Please provide your email").fill(UI_VET.VET_EMAIL);
+  await page.getByRole("button", { name: "Send me an OTP" }).click();
+  await expect(page.getByText(UI_VET.VET_EMAIL)).toBeVisible();
+  await page.getByLabel("Enter OTP").fill("000000");
+  await page.getByRole("button", { name: "Login" }).click();
+  await expect(page).toHaveURL(urlOf(RoutePath.VET_DEFAULT_LOGGED_IN_PAGE));
+}
+
+export async function loginTestAdmin(args: { page: Page }) {
+  const { page } = args;
+  await page.goto(urlOf(RoutePath.ADMIN_LOGIN_PAGE));
+  await page.getByLabel("Please provide your email").fill(UI_ADMIN.ADMIN_EMAIL);
+  await page.getByRole("button", { name: "Send me an OTP" }).click();
+  await expect(page.getByText(UI_ADMIN.ADMIN_EMAIL)).toBeVisible();
+  await page.getByLabel("Enter OTP").fill("000000");
+  await page.getByRole("button", { name: "Login" }).click();
+  await expect(page).toHaveURL(urlOf(RoutePath.ADMIN_DEFAULT_LOGGED_IN_PAGE));
 }

--- a/e2e/_ui_test_helpers.ts
+++ b/e2e/_ui_test_helpers.ts
@@ -19,9 +19,10 @@ export const UI_URLS = {
 } as const;
 
 export const UI_LOCATOR = {
-  NAV_BAR: "#nav-bar",
-  NAV_MENU_BUTTON: "#nav-menu-button",
-  SIDEBAR: "#sidebar",
+  NAV_BAR: "#bark-nav-bar",
+  NAV_MENU_BUTTON: "#bark-nav-menu-button",
+  SIDEBAR: "#bark-sidebar",
+  FOOTER: "#bark-footer",
 } as const;
 
 export const UI_USER = {

--- a/e2e/footer.spec.ts
+++ b/e2e/footer.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from "@playwright/test";
+import { UI_LOCATOR, UI_URLS, loginTestUser } from "./_ui_test_helpers";
+
+test.describe("footer when not logged-in", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(UI_URLS.ROOT);
+  });
+  test("it should show options to login as vet", async ({ page }) => {
+    await expect(
+      page.locator(UI_LOCATOR.FOOTER).getByRole("link", { name: "Vet Login" }),
+    ).toBeVisible();
+  });
+  test("it should show options to login as admin", async ({ page }) => {
+    await expect(
+      page
+        .locator(UI_LOCATOR.FOOTER)
+        .getByRole("link", { name: "Admin Login" }),
+    ).toBeVisible();
+  });
+});
+
+test.describe("footer when logged-in as a user", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(UI_URLS.ROOT);
+    await loginTestUser({ page });
+  });
+  test("it should not show options to login as vet", async ({ page }) => {
+    await expect(
+      page.locator(UI_LOCATOR.FOOTER).getByRole("link", { name: "Vet Login" }),
+    ).not.toBeVisible();
+  });
+  test("it should not show options to login as admin", async ({ page }) => {
+    await expect(
+      page
+        .locator(UI_LOCATOR.FOOTER)
+        .getByRole("link", { name: "Admin Login" }),
+    ).not.toBeVisible();
+  });
+});

--- a/e2e/footer.spec.ts
+++ b/e2e/footer.spec.ts
@@ -1,9 +1,10 @@
 import { test, expect } from "@playwright/test";
-import { UI_LOCATOR, UI_URLS, loginTestUser } from "./_ui_test_helpers";
+import { UI_LOCATOR, loginTestUser, urlOf } from "./_ui_test_helpers";
+import { RoutePath } from "@/lib/route-path";
 
 test.describe("footer when not logged-in", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(UI_URLS.ROOT);
+    await page.goto(urlOf(RoutePath.ROOT));
   });
   test("it should show options to login as vet", async ({ page }) => {
     await expect(
@@ -21,7 +22,7 @@ test.describe("footer when not logged-in", () => {
 
 test.describe("footer when logged-in as a user", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(UI_URLS.ROOT);
+    await page.goto(urlOf(RoutePath.ROOT));
     await loginTestUser({ page });
   });
   test("it should not show options to login as vet", async ({ page }) => {

--- a/e2e/nav-bar.spec.ts
+++ b/e2e/nav-bar.spec.ts
@@ -21,4 +21,8 @@ test.describe("nav bar when not logged-in", () => {
     await expect(link).toHaveAttribute("target", "_blank");
     await expect(link).toHaveAttribute("href", "https://www.barkbank.co/");
   });
+  test("it should not have a Logout option", async ({ page }) => {
+    const link = page.getByRole("link", { name: "Logout" });
+    await expect(link).not.toBeVisible();
+  });
 });

--- a/e2e/nav-bar.spec.ts
+++ b/e2e/nav-bar.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, Page } from "@playwright/test";
 import { UI_LOCATOR, UI_URLS, loginTestUser } from "./_ui_test_helpers";
+import { RoutePath } from "@/lib/route-path";
 
 test.describe("nav bar when not logged-in", () => {
   test.beforeEach(async ({ page }) => {
@@ -15,7 +16,7 @@ test.describe("nav bar when not logged-in", () => {
       .getByRole("link", { name: "Visit FAQ" });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("target", "_blank");
-    await expect(link).toHaveAttribute("href", UI_URLS.EXTERNAL_FAQ_PAGE);
+    await expect(link).toHaveAttribute("href", RoutePath.VISIT_FAQ);
   });
   test("it should have Visit Website", async ({ page }) => {
     const link = page
@@ -23,7 +24,7 @@ test.describe("nav bar when not logged-in", () => {
       .getByRole("link", { name: "Visit Website" });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("target", "_blank");
-    await expect(link).toHaveAttribute("href", UI_URLS.EXTERNAL_WEBSITE_PAGE);
+    await expect(link).toHaveAttribute("href", RoutePath.VISIT_WEBSITE);
   });
   test("it should not have a Logout option", async ({ page }) => {
     const link = page
@@ -48,7 +49,7 @@ test.describe("nav bar when logged-in as user", () => {
       .getByRole("link", { name: "Visit FAQ" });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("target", "_blank");
-    await expect(link).toHaveAttribute("href", UI_URLS.EXTERNAL_FAQ_PAGE);
+    await expect(link).toHaveAttribute("href", RoutePath.VISIT_FAQ);
   });
   test("it should have Visit Website", async ({ page }) => {
     const link = page
@@ -56,14 +57,13 @@ test.describe("nav bar when logged-in as user", () => {
       .getByRole("link", { name: "Visit Website" });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("target", "_blank");
-    await expect(link).toHaveAttribute("href", UI_URLS.EXTERNAL_WEBSITE_PAGE);
+    await expect(link).toHaveAttribute("href", RoutePath.VISIT_WEBSITE);
   });
   test("it should have a Logout option", async ({ page }) => {
     const link = page
       .locator(UI_LOCATOR.NAV_BAR)
       .getByRole("link", { name: "Logout" });
     await expect(link).toBeVisible();
-    await expect(link).toHaveAttribute("target", "");
-    await expect(link).toHaveAttribute("href", UI_URLS.LOGOUT_PAGE);
+    await expect(link).toHaveAttribute("href", RoutePath.LOGOUT_PAGE);
   });
 });

--- a/e2e/nav-bar.spec.ts
+++ b/e2e/nav-bar.spec.ts
@@ -16,7 +16,7 @@ test.describe("nav bar when not logged-in", () => {
       .getByRole("link", { name: "Visit FAQ" });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("target", "_blank");
-    await expect(link).toHaveAttribute("href", RoutePath.VISIT_FAQ);
+    await expect(link).toHaveAttribute("href", RoutePath.WEBSITE_FAQ_URL);
   });
   test("it should have Visit Website", async ({ page }) => {
     const link = page
@@ -24,7 +24,7 @@ test.describe("nav bar when not logged-in", () => {
       .getByRole("link", { name: "Visit Website" });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("target", "_blank");
-    await expect(link).toHaveAttribute("href", RoutePath.VISIT_WEBSITE);
+    await expect(link).toHaveAttribute("href", RoutePath.WEBSITE_URL);
   });
   test("it should not have a Logout option", async ({ page }) => {
     const link = page
@@ -48,7 +48,7 @@ test.describe("nav bar when logged-in as user", () => {
       .getByRole("link", { name: "Visit FAQ" });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("target", "_blank");
-    await expect(link).toHaveAttribute("href", RoutePath.VISIT_FAQ);
+    await expect(link).toHaveAttribute("href", RoutePath.WEBSITE_FAQ_URL);
   });
   test("it should have Visit Website", async ({ page }) => {
     const link = page
@@ -56,7 +56,7 @@ test.describe("nav bar when logged-in as user", () => {
       .getByRole("link", { name: "Visit Website" });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("target", "_blank");
-    await expect(link).toHaveAttribute("href", RoutePath.VISIT_WEBSITE);
+    await expect(link).toHaveAttribute("href", RoutePath.WEBSITE_URL);
   });
   test("it should have a Logout option", async ({ page }) => {
     const link = page

--- a/e2e/nav-bar.spec.ts
+++ b/e2e/nav-bar.spec.ts
@@ -1,28 +1,69 @@
 import { test, expect, Page } from "@playwright/test";
-import { UI_URLS } from "./_ui_test_helpers";
+import { UI_LOCATOR, UI_URLS, loginTestUser } from "./_ui_test_helpers";
 
 test.describe("nav bar when not logged-in", () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(UI_URLS.ROOT);
-    const menuButton = page.locator("#nav-menu-button");
+    const menuButton = page.locator(UI_LOCATOR.NAV_MENU_BUTTON);
     if (await menuButton.isVisible()) {
       await menuButton.click();
     }
   });
   test("it should have Visit FAQ", async ({ page }) => {
-    const link = page.getByRole("link", { name: "Visit FAQ" });
+    const link = page
+      .locator(UI_LOCATOR.NAV_BAR)
+      .getByRole("link", { name: "Visit FAQ" });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("target", "_blank");
-    await expect(link).toHaveAttribute("href", "https://www.barkbank.co/faq");
+    await expect(link).toHaveAttribute("href", UI_URLS.EXTERNAL_FAQ_PAGE);
   });
   test("it should have Visit Website", async ({ page }) => {
-    const link = page.getByRole("link", { name: "Visit Website" });
+    const link = page
+      .locator(UI_LOCATOR.NAV_BAR)
+      .getByRole("link", { name: "Visit Website" });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("target", "_blank");
-    await expect(link).toHaveAttribute("href", "https://www.barkbank.co/");
+    await expect(link).toHaveAttribute("href", UI_URLS.EXTERNAL_WEBSITE_PAGE);
   });
   test("it should not have a Logout option", async ({ page }) => {
-    const link = page.getByRole("link", { name: "Logout" });
+    const link = page
+      .locator(UI_LOCATOR.NAV_BAR)
+      .getByRole("link", { name: "Logout" });
     await expect(link).not.toBeVisible();
+  });
+});
+
+test.describe("nav bar when logged-in as user", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(UI_URLS.ROOT);
+    await loginTestUser({ page });
+    const menuButton = page.locator(UI_LOCATOR.NAV_MENU_BUTTON);
+    if (await menuButton.isVisible()) {
+      await menuButton.click();
+    }
+  });
+  test("it should have Visit FAQ", async ({ page }) => {
+    const link = page
+      .locator(UI_LOCATOR.NAV_BAR)
+      .getByRole("link", { name: "Visit FAQ" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("target", "_blank");
+    await expect(link).toHaveAttribute("href", UI_URLS.EXTERNAL_FAQ_PAGE);
+  });
+  test("it should have Visit Website", async ({ page }) => {
+    const link = page
+      .locator(UI_LOCATOR.NAV_BAR)
+      .getByRole("link", { name: "Visit Website" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("target", "_blank");
+    await expect(link).toHaveAttribute("href", UI_URLS.EXTERNAL_WEBSITE_PAGE);
+  });
+  test("it should have a Logout option", async ({ page }) => {
+    const link = page
+      .locator(UI_LOCATOR.NAV_BAR)
+      .getByRole("link", { name: "Logout" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("target", "");
+    await expect(link).toHaveAttribute("href", UI_URLS.LOGOUT_PAGE);
   });
 });

--- a/e2e/nav-bar.spec.ts
+++ b/e2e/nav-bar.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import { UI_LOCATOR, UI_URLS, loginTestUser } from "./_ui_test_helpers";
 import { RoutePath } from "@/lib/route-path";
 

--- a/e2e/nav-bar.spec.ts
+++ b/e2e/nav-bar.spec.ts
@@ -67,3 +67,22 @@ test.describe("nav bar when logged-in as user", () => {
     await expect(link).toHaveAttribute("href", RoutePath.LOGOUT_PAGE);
   });
 });
+
+test.describe("nav bar logout flow", () => {
+  test("for user", async ({ page }) => {
+    await page.goto(UI_URLS.ROOT);
+    await loginTestUser({ page });
+    const menuButton = page.locator(UI_LOCATOR.NAV_MENU_BUTTON);
+    if (await menuButton.isVisible()) {
+      await menuButton.click();
+    }
+    await page
+      .locator(UI_LOCATOR.NAV_BAR)
+      .getByRole("link", { name: "Logout" })
+      .click();
+    await page.waitForURL(UI_URLS.LOGOUT_PAGE);
+    await expect(page.getByRole("button", { name: "Logout" })).toBeVisible();
+    await page.getByRole("button", { name: "Logout" }).click();
+    await expect(page).toHaveURL(UI_URLS.ROOT);
+  });
+});

--- a/e2e/nav-bar.spec.ts
+++ b/e2e/nav-bar.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect } from "@playwright/test";
-import { UI_LOCATOR, UI_URLS, loginTestUser } from "./_ui_test_helpers";
+import { UI_LOCATOR, loginTestUser, urlOf } from "./_ui_test_helpers";
 import { RoutePath } from "@/lib/route-path";
 
 test.describe("nav bar when not logged-in", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(UI_URLS.ROOT);
+    await page.goto(urlOf(RoutePath.USER_LOGIN_PAGE));
     const menuButton = page.locator(UI_LOCATOR.NAV_MENU_BUTTON);
     if (await menuButton.isVisible()) {
       await menuButton.click();
@@ -36,7 +36,6 @@ test.describe("nav bar when not logged-in", () => {
 
 test.describe("nav bar when logged-in as user", () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto(UI_URLS.ROOT);
     await loginTestUser({ page });
     const menuButton = page.locator(UI_LOCATOR.NAV_MENU_BUTTON);
     if (await menuButton.isVisible()) {
@@ -70,7 +69,6 @@ test.describe("nav bar when logged-in as user", () => {
 
 test.describe("nav bar logout flow", () => {
   test("for user", async ({ page }) => {
-    await page.goto(UI_URLS.ROOT);
     await loginTestUser({ page });
     const menuButton = page.locator(UI_LOCATOR.NAV_MENU_BUTTON);
     if (await menuButton.isVisible()) {
@@ -80,9 +78,9 @@ test.describe("nav bar logout flow", () => {
       .locator(UI_LOCATOR.NAV_BAR)
       .getByRole("link", { name: "Logout" })
       .click();
-    await page.waitForURL(UI_URLS.LOGOUT_PAGE);
+    await page.waitForURL(urlOf(RoutePath.LOGOUT_PAGE));
     await expect(page.getByRole("button", { name: "Logout" })).toBeVisible();
     await page.getByRole("button", { name: "Logout" }).click();
-    await expect(page).toHaveURL(UI_URLS.ROOT);
+    await expect(page).toHaveURL(urlOf(RoutePath.USER_LOGIN_PAGE));
   });
 });

--- a/e2e/nav-bar.spec.ts
+++ b/e2e/nav-bar.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect, Page } from "@playwright/test";
+import { UI_URLS } from "./_ui_test_helpers";
+
+test.describe("nav bar when not logged-in", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(UI_URLS.ROOT);
+    const menuButton = page.locator("#nav-menu-button");
+    if (await menuButton.isVisible()) {
+      await menuButton.click();
+    }
+  });
+  test("it should have Visit FAQ", async ({ page }) => {
+    const link = page.getByRole("link", { name: "Visit FAQ" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("target", "_blank");
+    await expect(link).toHaveAttribute("href", "https://www.barkbank.co/faq");
+  });
+  test("it should have Visit Website", async ({ page }) => {
+    const link = page.getByRole("link", { name: "Visit Website" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("target", "_blank");
+    await expect(link).toHaveAttribute("href", "https://www.barkbank.co/");
+  });
+});

--- a/e2e/root-page.spec.ts
+++ b/e2e/root-page.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+import {
+  UI_URLS,
+  urlOf,
+  loginTestAdmin,
+  loginTestUser,
+  loginTestVet,
+} from "./_ui_test_helpers";
+import { RoutePath } from "@/lib/route-path";
+
+test.describe("root page", () => {
+  test("should route to user login page when not logged-in", async ({
+    page,
+  }) => {
+    await page.goto(urlOf(RoutePath.ROOT));
+    await page.waitForURL(urlOf(RoutePath.USER_LOGIN_PAGE));
+    await expect(page).toHaveURL(urlOf(RoutePath.USER_LOGIN_PAGE));
+  });
+  test("should route to user logged-in page when user is logged-in", async ({
+    page,
+  }) => {
+    await loginTestUser({ page });
+    await expect(page).toHaveURL(urlOf(RoutePath.USER_DEFAULT_LOGGED_IN_PAGE));
+    await page.goto(urlOf(RoutePath.USER_MY_ACCOUNT_PAGE));
+    await page.waitForURL(urlOf(RoutePath.USER_MY_ACCOUNT_PAGE));
+    await page.goto(urlOf(RoutePath.ROOT));
+    await expect(page).toHaveURL(urlOf(RoutePath.USER_DEFAULT_LOGGED_IN_PAGE));
+  });
+  test("should route to vet logged-in page when vet is logged-in", async ({
+    page,
+  }) => {
+    await loginTestVet({ page });
+    await expect(page).toHaveURL(urlOf(RoutePath.VET_DEFAULT_LOGGED_IN_PAGE));
+    await page.goto(urlOf(RoutePath.ROOT));
+    await expect(page).toHaveURL(urlOf(RoutePath.VET_DEFAULT_LOGGED_IN_PAGE));
+  });
+  test("should route to admin logged-in page when admin is logged-in", async ({
+    page,
+  }) => {
+    await loginTestAdmin({ page });
+    await expect(page).toHaveURL(urlOf(RoutePath.ADMIN_DEFAULT_LOGGED_IN_PAGE));
+    await page.goto(urlOf(RoutePath.ROOT));
+    await expect(page).toHaveURL(urlOf(RoutePath.ADMIN_DEFAULT_LOGGED_IN_PAGE));
+  });
+});

--- a/e2e/root-page.spec.ts
+++ b/e2e/root-page.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from "@playwright/test";
 import {
-  UI_URLS,
   urlOf,
   loginTestAdmin,
   loginTestUser,

--- a/e2e/user-login-page.spec.ts
+++ b/e2e/user-login-page.spec.ts
@@ -19,7 +19,6 @@ test.describe("user login page", () => {
     await expect(
       page.getByRole("button").getByText("Send me an OTP"),
     ).toBeVisible();
-    await expect(page.getByRole("button").getByText("Cancel")).toBeVisible();
     await expect(page.getByRole("button").getByText("Login")).toBeVisible();
 
     // getByLabel selects input fields by associated label
@@ -67,14 +66,6 @@ test.describe("user login flow", () => {
     await fillOtp("000000", page);
     await clickLogin(page);
     await expect(page).toHaveURL(urlOf(RoutePath.USER_MY_PETS));
-  });
-});
-
-// TODO: Remove cancel button
-test.describe("user cancel login flow", () => {
-  test("it brings user back to root", async ({ page }) => {
-    await clickCancel(page);
-    await expect(page).toHaveURL(urlOf(RoutePath.USER_LOGIN_PAGE));
   });
 });
 

--- a/e2e/user-login-page.spec.ts
+++ b/e2e/user-login-page.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, Page } from "@playwright/test";
 import { UI_URLS, UI_USER } from "./_ui_test_helpers";
+import { RoutePath } from "@/lib/route-path";
 
 test.beforeEach(async ({ page }) => {
   await page.goto(UI_URLS.USER_LOGIN);
@@ -25,6 +26,12 @@ test.describe("user login page", () => {
     await expect(page.getByLabel("Please provide your email")).toBeEditable();
     await expect(page.getByLabel("Enter OTP")).toBeEditable();
   });
+
+  test("it should have a link to user registration page", async ({page}) => {
+    const link = page.getByRole("link", {name: "registration"});
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", RoutePath.USER_REGISTRATION);
+  })
 });
 
 test.describe("user login validations", () => {

--- a/e2e/user-login-page.spec.ts
+++ b/e2e/user-login-page.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect, Page } from "@playwright/test";
-import { UI_URLS, UI_USER } from "./_ui_test_helpers";
+import { UI_USER, urlOf } from "./_ui_test_helpers";
 import { RoutePath } from "@/lib/route-path";
 
 test.beforeEach(async ({ page }) => {
-  await page.goto(UI_URLS.USER_LOGIN);
+  await page.goto(urlOf(RoutePath.USER_LOGIN_PAGE));
 });
 
 test.describe("user login page", () => {
@@ -66,14 +66,15 @@ test.describe("user login flow", () => {
     await expectVisible(`An OTP has been sent to ${UI_USER.USER_EMAIL}`, page);
     await fillOtp("000000", page);
     await clickLogin(page);
-    await expect(page).toHaveURL(UI_URLS.USER_MY_PETS);
+    await expect(page).toHaveURL(urlOf(RoutePath.USER_MY_PETS));
   });
 });
 
+// TODO: Remove cancel button
 test.describe("user cancel login flow", () => {
   test("it brings user back to root", async ({ page }) => {
     await clickCancel(page);
-    await expect(page).toHaveURL(UI_URLS.ROOT);
+    await expect(page).toHaveURL(urlOf(RoutePath.USER_LOGIN_PAGE));
   });
 });
 

--- a/e2e/user-login-page.spec.ts
+++ b/e2e/user-login-page.spec.ts
@@ -27,11 +27,11 @@ test.describe("user login page", () => {
     await expect(page.getByLabel("Enter OTP")).toBeEditable();
   });
 
-  test("it should have a link to user registration page", async ({page}) => {
-    const link = page.getByRole("link", {name: "registration"});
+  test("it should have a link to user registration page", async ({ page }) => {
+    const link = page.getByRole("link", { name: "register" });
     await expect(link).toBeVisible();
     await expect(link).toHaveAttribute("href", RoutePath.USER_REGISTRATION);
-  })
+  });
 });
 
 test.describe("user login validations", () => {

--- a/e2e/user-my-account.spec.ts
+++ b/e2e/user-my-account.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from "@playwright/test";
-import { UI_URLS, UI_USER, loginTestUser } from "./_ui_test_helpers";
+import { UI_USER, loginTestUser, urlOf } from "./_ui_test_helpers";
+import { RoutePath } from "@/lib/route-path";
 
 test.beforeEach(async ({ page }) => {
   await loginTestUser({ page });
   await page.getByRole("link", { name: "Icon for the My Account" }).click();
-  await page.waitForURL(UI_URLS.USER_MY_ACCOUNT);
+  await page.waitForURL(urlOf(RoutePath.USER_MY_ACCOUNT_PAGE));
 });
 
 test.describe("user my account", () => {

--- a/e2e/user-my-pets.spec.ts
+++ b/e2e/user-my-pets.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect } from "@playwright/test";
-import { UI_URLS, loginTestUser } from "./_ui_test_helpers";
+import { loginTestUser, urlOf } from "./_ui_test_helpers";
+import { RoutePath } from "@/lib/route-path";
 
 test.beforeEach(async ({ page }) => {
   await loginTestUser({ page });
   await page.getByRole("link", { name: "Icon for the My Pets option" }).click();
-  await page.waitForURL(UI_URLS.USER_MY_PETS);
+  await page.waitForURL(urlOf(RoutePath.USER_MY_PETS));
 });
 
 test.describe("user my pets", () => {

--- a/e2e/user-sidebar.spec.ts
+++ b/e2e/user-sidebar.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test";
+import { UI_LOCATOR, loginTestUser } from "./_ui_test_helpers";
+import { RoutePath } from "@/lib/route-path";
+
+test.describe("user sidebar", () => {
+  test.beforeEach(async ({ page }) => {
+    await loginTestUser({ page });
+  });
+  test("it should have My Pets", async ({ page }) => {
+    const link = page
+      .locator(UI_LOCATOR.SIDEBAR)
+      .getByRole("link", { name: "My Pets" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", RoutePath.USER_MY_PETS);
+  });
+  test("it should have My Account", async ({ page }) => {
+    const link = page
+      .locator(UI_LOCATOR.SIDEBAR)
+      .getByRole("link", { name: "My Account" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", RoutePath.USER_MY_ACCOUNT_PAGE);
+  });
+  test("it should have Criteria", async ({ page }) => {
+    const link = page
+      .locator(UI_LOCATOR.SIDEBAR)
+      .getByRole("link", { name: "Criteria" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", RoutePath.USER_CRITERIA);
+  });
+  test("it should have Process", async ({ page }) => {
+    const link = page
+      .locator(UI_LOCATOR.SIDEBAR)
+      .getByRole("link", { name: "Process" });
+    await expect(link).toBeVisible();
+    await expect(link).toHaveAttribute("href", RoutePath.USER_PROCESS);
+  });
+});

--- a/scripts/test_no_wip_tasks_remaining.sh
+++ b/scripts/test_no_wip_tasks_remaining.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-OUTPUT=$(grep -R 'WIP' src tests db)
+OUTPUT=$(grep -R 'WIP' src tests db e2e)
 if [[ -z "$OUTPUT" ]]; then
     echo "PASS"
     exit 0
 else
     echo "FAIL - The following WIP comments remain"
     echo
-    grep --color=always -R 'WIP' src tests db
+    grep --color=always -R 'WIP' src tests db e2e
     echo
     exit 1
 fi

--- a/src/app/_components/header-items.tsx
+++ b/src/app/_components/header-items.tsx
@@ -2,15 +2,16 @@
 
 import Image from "next/image";
 import React from "react";
-import { CircleUser, MenuIcon, XIcon } from "lucide-react";
+import { MenuIcon, XIcon } from "lucide-react";
 import { RoutePath } from "@/lib/route-path";
 import Link from "next/link";
 import { IMG_PATH } from "@/lib/image-path";
 import { Button } from "@/components/ui/button";
 import * as Collapsible from "@radix-ui/react-collapsible";
-import { AccountType } from "@/lib/auth-models";
+import { useSession } from "next-auth/react";
 
-const MobileNav = ({ accountType }: { accountType?: AccountType }) => {
+const MobileNav = (props: {isLoggedIn: boolean}) => {
+  const {isLoggedIn} = props;
   const [isOpen, setIsOpen] = React.useState(false);
 
   return (
@@ -52,7 +53,7 @@ const MobileNav = ({ accountType }: { accountType?: AccountType }) => {
             >
               Visit FAQ
             </Link>
-            {accountType !== undefined && (
+            {isLoggedIn && (
               <Link className="text-right" href={RoutePath.LOGOUT_PAGE}>
                 Logout
               </Link>
@@ -64,7 +65,8 @@ const MobileNav = ({ accountType }: { accountType?: AccountType }) => {
   );
 };
 
-const DesktopNav = ({ accountType }: { accountType?: AccountType }) => {
+const DesktopNav = (props: {isLoggedIn: boolean}) => {
+  const {isLoggedIn} = props;
   return (
     <nav className="flex h-[72px] flex-row items-center justify-between border-b bg-white shadow-lg">
       <div className="ml-8 w-[72px] flex-none">
@@ -85,7 +87,7 @@ const DesktopNav = ({ accountType }: { accountType?: AccountType }) => {
         <Link target="_blank" href={RoutePath.VISIT_FAQ}>
           Visit FAQ
         </Link>
-        {accountType !== undefined && (
+        {isLoggedIn && (
           <Link className="text-right" href={RoutePath.LOGOUT_PAGE}>
             Logout
           </Link>
@@ -95,14 +97,17 @@ const DesktopNav = ({ accountType }: { accountType?: AccountType }) => {
   );
 };
 
-const HeaderItems = ({ accountType }: { accountType?: AccountType }) => {
+const HeaderItems = () => {
+  const session = useSession();
+  const {status} = session;
+  const isLoggedIn = status === "authenticated";
   return (
     <div className="sticky top-0 z-10" id="nav-bar">
       <div className="md:hidden">
-        <MobileNav accountType={accountType} />
+        <MobileNav isLoggedIn={isLoggedIn} />
       </div>
       <div className="hidden md:block">
-        <DesktopNav accountType={accountType} />
+        <DesktopNav isLoggedIn={isLoggedIn} />
       </div>
     </div>
   );

--- a/src/app/_components/header-items.tsx
+++ b/src/app/_components/header-items.tsx
@@ -27,7 +27,7 @@ const MobileNav = (props: { isLoggedIn: boolean }) => {
             />
           </Link>
           <Collapsible.Trigger asChild>
-            <Button variant="outline" size="icon" id="nav-menu-button">
+            <Button variant="outline" size="icon" id="bark-nav-menu-button">
               {isOpen ? (
                 <XIcon className="h-4 w-4" />
               ) : (
@@ -102,7 +102,7 @@ const HeaderItems = () => {
   const { status } = session;
   const isLoggedIn = status === "authenticated";
   return (
-    <div className="sticky top-0 z-10" id="nav-bar">
+    <div className="sticky top-0 z-10" id="bark-nav-bar">
       <div className="md:hidden">
         <MobileNav isLoggedIn={isLoggedIn} />
       </div>

--- a/src/app/_components/header-items.tsx
+++ b/src/app/_components/header-items.tsx
@@ -26,7 +26,7 @@ const MobileNav = ({ accountType }: { accountType?: AccountType }) => {
             />
           </Link>
           <Collapsible.Trigger asChild>
-            <Button variant="outline" size="icon">
+            <Button variant="outline" size="icon" id="nav-menu-button">
               {isOpen ? (
                 <XIcon className="h-4 w-4" />
               ) : (
@@ -38,23 +38,19 @@ const MobileNav = ({ accountType }: { accountType?: AccountType }) => {
 
         <Collapsible.Content>
           <div className="mx-4 my-2 flex flex-col gap-2">
-            <Link className="text-right" href={RoutePath.ROOT}>
-              Home
+            <Link
+              className="text-right"
+              target="_blank"
+              href={RoutePath.VISIT_FAQ}
+            >
+              Visit FAQ
             </Link>
-            <Link className="text-right" href={RoutePath.ABOUT_US}>
-              About Us
-            </Link>
-            <Link className="text-right" href={RoutePath.BE_A_DONOR}>
-              Be a Donor
-            </Link>
-            <Link className="text-right" href={RoutePath.ARTICLES}>
-              Articles
-            </Link>
-            <Link className="text-right" href={RoutePath.FAQ}>
-              FAQ
-            </Link>
-            <Link className="text-right" href={RoutePath.INFO}>
-              Info
+            <Link
+              className="text-right"
+              target="_blank"
+              href={RoutePath.VISIT_WEBSITE}
+            >
+              Visit Website
             </Link>
             <Link
               className="flex flex-row-reverse"
@@ -84,12 +80,12 @@ const DesktopNav = ({ accountType }: { accountType?: AccountType }) => {
       </div>
 
       <div className="mr-8 flex gap-8 gap-x-8">
-        <Link href={RoutePath.ROOT}>Home</Link>
-        <Link href={RoutePath.ABOUT_US}>About Us</Link>
-        <Link href={RoutePath.BE_A_DONOR}>Be a Donor</Link>
-        <Link href={RoutePath.ARTICLES}>Articles</Link>
-        <Link href={RoutePath.FAQ}>FAQ</Link>
-        <Link href={RoutePath.INFO}>Info</Link>
+        <Link target="_blank" href={RoutePath.VISIT_FAQ}>
+          Visit FAQ
+        </Link>
+        <Link target="_blank" href={RoutePath.VISIT_WEBSITE}>
+          Visit Website
+        </Link>
         <Link href={RoutePath.ACCOUNT_DASHBOARD(accountType)}>
           <CircleUser />
         </Link>

--- a/src/app/_components/header-items.tsx
+++ b/src/app/_components/header-items.tsx
@@ -10,8 +10,8 @@ import { Button } from "@/components/ui/button";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { useSession } from "next-auth/react";
 
-const MobileNav = (props: {isLoggedIn: boolean}) => {
-  const {isLoggedIn} = props;
+const MobileNav = (props: { isLoggedIn: boolean }) => {
+  const { isLoggedIn } = props;
   const [isOpen, setIsOpen] = React.useState(false);
 
   return (
@@ -65,8 +65,8 @@ const MobileNav = (props: {isLoggedIn: boolean}) => {
   );
 };
 
-const DesktopNav = (props: {isLoggedIn: boolean}) => {
-  const {isLoggedIn} = props;
+const DesktopNav = (props: { isLoggedIn: boolean }) => {
+  const { isLoggedIn } = props;
   return (
     <nav className="flex h-[72px] flex-row items-center justify-between border-b bg-white shadow-lg">
       <div className="ml-8 w-[72px] flex-none">
@@ -99,7 +99,7 @@ const DesktopNav = (props: {isLoggedIn: boolean}) => {
 
 const HeaderItems = () => {
   const session = useSession();
-  const {status} = session;
+  const { status } = session;
   const isLoggedIn = status === "authenticated";
   return (
     <div className="sticky top-0 z-10" id="nav-bar">

--- a/src/app/_components/header-items.tsx
+++ b/src/app/_components/header-items.tsx
@@ -42,14 +42,14 @@ const MobileNav = (props: { isLoggedIn: boolean }) => {
             <Link
               className="text-right"
               target="_blank"
-              href={RoutePath.VISIT_WEBSITE}
+              href={RoutePath.WEBSITE_URL}
             >
               Visit Website
             </Link>
             <Link
               className="text-right"
               target="_blank"
-              href={RoutePath.VISIT_FAQ}
+              href={RoutePath.WEBSITE_FAQ_URL}
             >
               Visit FAQ
             </Link>
@@ -81,10 +81,10 @@ const DesktopNav = (props: { isLoggedIn: boolean }) => {
       </div>
 
       <div className="mr-8 flex gap-8 gap-x-8">
-        <Link target="_blank" href={RoutePath.VISIT_WEBSITE}>
+        <Link target="_blank" href={RoutePath.WEBSITE_URL}>
           Visit Website
         </Link>
-        <Link target="_blank" href={RoutePath.VISIT_FAQ}>
+        <Link target="_blank" href={RoutePath.WEBSITE_FAQ_URL}>
           Visit FAQ
         </Link>
         {isLoggedIn && (

--- a/src/app/_components/header-items.tsx
+++ b/src/app/_components/header-items.tsx
@@ -41,23 +41,22 @@ const MobileNav = ({ accountType }: { accountType?: AccountType }) => {
             <Link
               className="text-right"
               target="_blank"
-              href={RoutePath.VISIT_FAQ}
-            >
-              Visit FAQ
-            </Link>
-            <Link
-              className="text-right"
-              target="_blank"
               href={RoutePath.VISIT_WEBSITE}
             >
               Visit Website
             </Link>
             <Link
-              className="flex flex-row-reverse"
-              href={RoutePath.ACCOUNT_DASHBOARD(accountType)}
+              className="text-right"
+              target="_blank"
+              href={RoutePath.VISIT_FAQ}
             >
-              <CircleUser />
+              Visit FAQ
             </Link>
+            {accountType !== undefined && (
+              <Link className="text-right" href={RoutePath.LOGOUT_PAGE}>
+                Logout
+              </Link>
+            )}
           </div>
         </Collapsible.Content>
       </Collapsible.Root>
@@ -80,15 +79,17 @@ const DesktopNav = ({ accountType }: { accountType?: AccountType }) => {
       </div>
 
       <div className="mr-8 flex gap-8 gap-x-8">
-        <Link target="_blank" href={RoutePath.VISIT_FAQ}>
-          Visit FAQ
-        </Link>
         <Link target="_blank" href={RoutePath.VISIT_WEBSITE}>
           Visit Website
         </Link>
-        <Link href={RoutePath.ACCOUNT_DASHBOARD(accountType)}>
-          <CircleUser />
+        <Link target="_blank" href={RoutePath.VISIT_FAQ}>
+          Visit FAQ
         </Link>
+        {accountType !== undefined && (
+          <Link className="text-right" href={RoutePath.LOGOUT_PAGE}>
+            Logout
+          </Link>
+        )}
       </div>
     </nav>
   );
@@ -96,12 +97,12 @@ const DesktopNav = ({ accountType }: { accountType?: AccountType }) => {
 
 const HeaderItems = ({ accountType }: { accountType?: AccountType }) => {
   return (
-    <div className="sticky top-0 z-10">
+    <div className="sticky top-0 z-10" id="nav-bar">
       <div className="md:hidden">
-        <MobileNav />
+        <MobileNav accountType={accountType} />
       </div>
       <div className="hidden md:block">
-        <DesktopNav />
+        <DesktopNav accountType={accountType} />
       </div>
     </div>
   );

--- a/src/app/_components/root-footer.tsx
+++ b/src/app/_components/root-footer.tsx
@@ -1,7 +1,10 @@
+"use client";
+
 import React from "react";
 import { BarkNavRoute } from "../../components/bark/bark-nav";
 import { RoutePath } from "@/lib/route-path";
 import Link from "next/link";
+import { useSession } from "next-auth/react";
 
 const footerRoutes: BarkNavRoute[] = [
   {
@@ -18,22 +21,36 @@ const footerRoutes: BarkNavRoute[] = [
   },
 ];
 
+const loginPages: BarkNavRoute[] = [
+  {
+    label: "Vet Login",
+    href: RoutePath.VET_LOGIN_PAGE,
+  },
+  {
+    label: "Admin Login",
+    href: RoutePath.ADMIN_LOGIN_PAGE,
+  },
+];
+
 const RootFooter = () => {
+  const session = useSession();
+  const { status } = session;
+  const routes =
+    status === "unauthenticated"
+      ? [...footerRoutes, ...loginPages]
+      : footerRoutes;
   return (
-    <div className=" flex min-h-[100px] w-full items-center justify-center bg-grey sm:min-h-[200px]">
-      <div className="flex sm:w-[40%]">
-        {footerRoutes.map((route) => {
-          return (
-            <Link
-              key={route.label}
-              href={route.href}
-              className="w-20 sm:w-full"
-            >
-              {route.label}
-            </Link>
-          );
-        })}
-      </div>
+    <div
+      id="bark-footer"
+      className="flex w-full flex-col items-center justify-center bg-grey md:flex-row"
+    >
+      {routes.map((route) => {
+        return (
+          <Link key={route.label} href={route.href} className="m-3 md:w-32">
+            {route.label}
+          </Link>
+        );
+      })}
     </div>
   );
 };

--- a/src/app/_components/root-header.tsx
+++ b/src/app/_components/root-header.tsx
@@ -1,13 +1,8 @@
 import React from "react";
-import { getLoggedInSession } from "@/lib/auth";
-
 import HeaderItems from "./header-items";
 
 const RootHeader = async () => {
-  const session = await getLoggedInSession();
-  const accountType = session?.accountType;
-
-  return <HeaderItems accountType={accountType} />;
+  return <HeaderItems />;
 };
 
 export default RootHeader;

--- a/src/app/admin/(logged-in)/layout.tsx
+++ b/src/app/admin/(logged-in)/layout.tsx
@@ -33,10 +33,6 @@ export default async function Layout(props: { children: React.ReactNode }) {
       iconSrc: IMG_PATH.SIDEBAR_KEY,
       iconLightSrc: IMG_PATH.SIDEBAR_KEY_LIGHT,
     },
-    {
-      label: "Logout",
-      href: RoutePath.LOGOUT_PAGE,
-    },
   ];
   return (
     <BarkSidebarLayout routes={routes}>{props.children}</BarkSidebarLayout>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,44 +1,22 @@
 "use server";
 
-import { BarkH1, BarkP } from "@/components/bark/bark-typography";
+import { getLoggedInSession } from "@/lib/auth";
+import { AccountType } from "@/lib/auth-models";
 import { RoutePath } from "@/lib/route-path";
-import Link from "next/link";
+import { redirect } from "next/navigation";
 
 export default async function Page() {
-  const loginOptions = [
-    {
-      label: "USER REGISTRATION",
-      href: RoutePath.USER_REGISTRATION,
-    },
-    {
-      label: "USER LOGIN",
-      href: RoutePath.USER_LOGIN_PAGE,
-    },
-    {
-      label: "VET LOGIN",
-      href: RoutePath.VET_LOGIN_PAGE,
-    },
-    {
-      label: "ADMIN LOGIN",
-      href: RoutePath.ADMIN_LOGIN_PAGE,
-    },
-  ];
-  return (
-    <>
-      <div className="p-6">
-        <BarkH1>Bark Bank</BarkH1>
-        <ul>
-          {loginOptions.map((opt) => (
-            <li className="mt-6" key={opt.label}>
-              <Link key={opt.label} href={opt.href}>
-                <div className="flex h-24 min-w-[180px] max-w-[360px] items-center justify-center rounded-md border-2 border-solid border-brand bg-brand-light shadow-md hover:bg-brand">
-                  <p className="text-center text-xl">{opt.label}</p>
-                </div>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </>
-  );
+  const session = await getLoggedInSession();
+  if (session === null) {
+    redirect(RoutePath.USER_LOGIN_PAGE);
+  }
+
+  const { accountType } = session;
+  if (accountType === AccountType.VET) {
+    redirect(RoutePath.VET_DEFAULT_LOGGED_IN_PAGE);
+  }
+  if (accountType === AccountType.ADMIN) {
+    redirect(RoutePath.ADMIN_DEFAULT_LOGGED_IN_PAGE);
+  }
+  redirect(RoutePath.USER_DEFAULT_LOGGED_IN_PAGE);
 }

--- a/src/app/user/(logged-in)/layout.tsx
+++ b/src/app/user/(logged-in)/layout.tsx
@@ -27,10 +27,6 @@ export default async function Layout(props: { children: React.ReactNode }) {
       iconSrc: IMG_PATH.SIDEBAR_KEY,
       iconLightSrc: IMG_PATH.SIDEBAR_KEY_LIGHT,
     },
-    {
-      label: "Logout",
-      href: RoutePath.LOGOUT_PAGE,
-    },
   ];
   return (
     <BarkSidebarLayout routes={routes}>{props.children}</BarkSidebarLayout>

--- a/src/app/user/(logged-in)/layout.tsx
+++ b/src/app/user/(logged-in)/layout.tsx
@@ -27,6 +27,14 @@ export default async function Layout(props: { children: React.ReactNode }) {
       iconSrc: IMG_PATH.SIDEBAR_KEY,
       iconLightSrc: IMG_PATH.SIDEBAR_KEY_LIGHT,
     },
+    {
+      label: "Criteria",
+      href: RoutePath.USER_CRITERIA,
+    },
+    {
+      label: "Process",
+      href: RoutePath.USER_PROCESS,
+    },
   ];
   return (
     <BarkSidebarLayout routes={routes}>{props.children}</BarkSidebarLayout>

--- a/src/app/user/login/page.tsx
+++ b/src/app/user/login/page.tsx
@@ -22,6 +22,15 @@ export default async function Page() {
           to create an account.
         </>
       }
+      emailDescription={
+        <>
+          If you are a new user, please{" "}
+          <Link href={RoutePath.USER_REGISTRATION} className="text-blue-400">
+            register here
+          </Link>
+          .
+        </>
+      }
     />
   );
 }

--- a/src/app/vet/(logged-in)/layout.tsx
+++ b/src/app/vet/(logged-in)/layout.tsx
@@ -26,10 +26,6 @@ export default async function Layout(props: { children: React.ReactNode }) {
       label: "Root 3",
       href: RoutePath.ROOT,
     },
-    {
-      label: "Logout",
-      href: RoutePath.LOGOUT_PAGE,
-    },
   ];
   return (
     <BarkSidebarLayout routes={routes}>{props.children}</BarkSidebarLayout>

--- a/src/components/bark/bark-form.tsx
+++ b/src/components/bark/bark-form.tsx
@@ -78,7 +78,7 @@ export function BarkFormInput(props: {
   label: string;
   type?: "text" | "password" | "number" | "email";
   placeholder?: string;
-  description?: string;
+  description?: string | React.ReactNode;
   children?: React.ReactNode;
 }) {
   const { form, name, label, type, placeholder, description, children } = props;

--- a/src/components/bark/bark-sidebar.tsx
+++ b/src/components/bark/bark-sidebar.tsx
@@ -58,7 +58,7 @@ export function BarkSidebarLayout(props: {
 }) {
   const currentPath = usePathname();
   return (
-    <div className="flex flex-row" id="sidebar">
+    <div className="flex flex-row" id="bark-sidebar">
       {/* Sidebar */}
       <div className="flex min-h-screen w-[78px] flex-col items-center bg-brand px-[10px] py-[12px] md:w-[220px]">
         {props.routes.map((route) => {

--- a/src/components/bark/bark-sidebar.tsx
+++ b/src/components/bark/bark-sidebar.tsx
@@ -58,7 +58,7 @@ export function BarkSidebarLayout(props: {
 }) {
   const currentPath = usePathname();
   return (
-    <div className="flex flex-row">
+    <div className="flex flex-row" id="sidebar">
       {/* Sidebar */}
       <div className="flex min-h-screen w-[78px] flex-col items-center bg-brand px-[10px] py-[12px] md:w-[220px]">
         {props.routes.map((route) => {

--- a/src/components/bark/login/bark-login-form.tsx
+++ b/src/components/bark/login/bark-login-form.tsx
@@ -18,6 +18,7 @@ import { RoutePath } from "@/lib/route-path";
 import { sendLoginOtp } from "@/lib/server-actions/send-login-otp";
 import { AccountType } from "@/lib/auth-models";
 import { FormMessage } from "@/components/ui/form";
+import Link from "next/link";
 
 const FORM_SCHEMA = z.object({
   email: z.string().email(),
@@ -30,8 +31,10 @@ export default function BarkLoginForm(props: {
   accountType: AccountType;
   successPath: string;
   noAccountErrorMessage: string | React.ReactNode;
+  emailDescription?: string | React.ReactNode;
 }) {
-  const { accountType, successPath, noAccountErrorMessage } = props;
+  const { accountType, successPath, noAccountErrorMessage, emailDescription } =
+    props;
   const router = useRouter();
   const hasErrorInQueryString = useSearchParams().get("error") !== null;
   const [shouldShowLoginFailed, setShouldShowLoginFailed] = useState(
@@ -111,6 +114,7 @@ export default function BarkLoginForm(props: {
           form={form}
           name="email"
           label="Please provide your email address"
+          description={emailDescription}
         />
         {/* TODO - We need a CAPTCHA to prevent abuse of Send me an OTP */}
         <BarkFormButton onClick={onRequestOtp}>Send me an OTP</BarkFormButton>

--- a/src/components/bark/login/bark-login-form.tsx
+++ b/src/components/bark/login/bark-login-form.tsx
@@ -117,7 +117,9 @@ export default function BarkLoginForm(props: {
           description={emailDescription}
         />
         {/* TODO - We need a CAPTCHA to prevent abuse of Send me an OTP */}
-        <BarkFormButton onClick={onRequestOtp}>Send me an OTP</BarkFormButton>
+        <BarkFormButton className="w-full md:w-48" onClick={onRequestOtp}>
+          Send me an OTP
+        </BarkFormButton>
         {recipientEmail !== "" && (
           <BarkFormParagraph>
             An OTP has been sent to {recipientEmail}
@@ -129,12 +131,9 @@ export default function BarkLoginForm(props: {
           </FormMessage>
         )}
         <BarkFormInput form={form} name="otp" label="Enter OTP" />
-        <div className="flex w-full gap-x-4">
-          <BarkFormButton onClick={async () => router.push(RoutePath.ROOT)}>
-            Cancel
-          </BarkFormButton>
-          <BarkFormSubmitButton>Login</BarkFormSubmitButton>
-        </div>
+        <BarkFormSubmitButton className="w-full md:w-48">
+          Login
+        </BarkFormSubmitButton>
         <BarkFormError form={form} />
         {shouldShowLoginFailed && (
           <FormMessage className="mt-6 text-red-500">Login Failed</FormMessage>

--- a/src/components/bark/login/bark-login-page.tsx
+++ b/src/components/bark/login/bark-login-page.tsx
@@ -41,7 +41,7 @@ export default async function BarkLoginPage(props: {
             <BarkH1>Bark Bank Canine Blood Donation Pawtal</BarkH1>
           </div>
         </div>
-        <div className="mx-auto max-w-[1100px] sm:w-[36rem] sm:px-6 sm:py-10 md:w-full ">
+        <div className="w-full max-w-[1000px] px-3">
           <BarkH2>{title}</BarkH2>
           <BarkLoginForm
             accountType={accountType}

--- a/src/components/bark/login/bark-login-page.tsx
+++ b/src/components/bark/login/bark-login-page.tsx
@@ -13,9 +13,16 @@ export default async function BarkLoginPage(props: {
   successPath: string;
   logoSrc: string;
   noAccountErrorMessage: string | React.ReactNode;
+  emailDescription?: string | React.ReactNode;
 }) {
-  const { title, accountType, successPath, logoSrc, noAccountErrorMessage } =
-    props;
+  const {
+    title,
+    accountType,
+    successPath,
+    logoSrc,
+    noAccountErrorMessage,
+    emailDescription,
+  } = props;
   if (await isLoggedIn(accountType)) {
     redirect(successPath);
   }
@@ -40,6 +47,7 @@ export default async function BarkLoginPage(props: {
             accountType={accountType}
             successPath={successPath}
             noAccountErrorMessage={noAccountErrorMessage}
+            emailDescription={emailDescription}
           />
         </div>
       </div>

--- a/src/lib/route-path.ts
+++ b/src/lib/route-path.ts
@@ -37,19 +37,4 @@ export class RoutePath {
 
   static readonly VISIT_FAQ = "https://www.barkbank.co/faq";
   static readonly VISIT_WEBSITE = "https://www.barkbank.co/";
-
-  static readonly ACCOUNT_DASHBOARD = (
-    accountType: AccountType | undefined,
-  ) => {
-    if (accountType === AccountType.ADMIN) {
-      return RoutePath.ADMIN_DASHBOARD_PAGE;
-    }
-    if (accountType === AccountType.VET) {
-      return RoutePath.VET_DASHBOARD_PAGE;
-    }
-    if (accountType === AccountType.USER) {
-      return RoutePath.USER_DEFAULT_LOGGED_IN_PAGE;
-    }
-    return RoutePath.ROOT;
-  };
 }

--- a/src/lib/route-path.ts
+++ b/src/lib/route-path.ts
@@ -35,6 +35,6 @@ export class RoutePath {
   static readonly BE_A_DONOR = "/be-a-donor";
   static readonly INFO = "/info";
 
-  static readonly VISIT_FAQ = "https://www.barkbank.co/faq";
-  static readonly VISIT_WEBSITE = "https://www.barkbank.co/";
+  static readonly WEBSITE_FAQ_URL = "https://www.barkbank.co/faq";
+  static readonly WEBSITE_URL = "https://www.barkbank.co/";
 }

--- a/src/lib/route-path.ts
+++ b/src/lib/route-path.ts
@@ -11,6 +11,8 @@ export class RoutePath {
   static readonly USER_MY_ACCOUNT_PAGE = "/user/my-account";
   static readonly USER_VIEW_DOG = (dogId: string) => `/user/dogs/${dogId}`;
   static readonly USER_EDIT_DOG = (dogId: string) => `/user/dogs/${dogId}/edit`;
+  static readonly USER_CRITERIA = "/user/criteria";
+  static readonly USER_PROCESS = "/user/process";
 
   static readonly USER_DEFAULT_LOGGED_IN_PAGE = RoutePath.USER_MY_PETS;
 

--- a/src/lib/route-path.ts
+++ b/src/lib/route-path.ts
@@ -30,7 +30,9 @@ export class RoutePath {
   static readonly ABOUT_US = "/about";
   static readonly BE_A_DONOR = "/be-a-donor";
   static readonly INFO = "/info";
-  static readonly FAQ = "/faq";
+
+  static readonly VISIT_FAQ = "https://www.barkbank.co/faq";
+  static readonly VISIT_WEBSITE = "https://www.barkbank.co/";
 
   static readonly ACCOUNT_DASHBOARD = (
     accountType: AccountType | undefined,

--- a/src/lib/route-path.ts
+++ b/src/lib/route-path.ts
@@ -18,11 +18,13 @@ export class RoutePath {
 
   static readonly VET_LOGIN_PAGE = "/vet/login";
   static readonly VET_DASHBOARD_PAGE = "/vet/dashboard";
+  static readonly VET_DEFAULT_LOGGED_IN_PAGE = RoutePath.VET_DASHBOARD_PAGE;
 
   static readonly ADMIN_LOGIN_PAGE = "/admin/login";
   static readonly ADMIN_DASHBOARD_PAGE = "/admin/dashboard";
   static readonly ADMIN_DATABASE_PAGE = "/admin/database";
   static readonly ADMIN_USER_ACCESS_PAGE = "/admin/user-access";
+  static readonly ADMIN_DEFAULT_LOGGED_IN_PAGE = RoutePath.ADMIN_DASHBOARD_PAGE;
 
   static readonly CONTACT_US = "/contact-us";
   static readonly PRIVACY_POLICY = "/privacy-policy";

--- a/tests/RoutePath.test.ts
+++ b/tests/RoutePath.test.ts
@@ -1,4 +1,3 @@
-import { AccountType } from "@/lib/auth-models";
 import { RoutePath } from "@/lib/route-path";
 
 describe("RoutePath", () => {
@@ -10,26 +9,5 @@ describe("RoutePath", () => {
   });
   it("should have a path for USER_EDIT_DOG(dogId)", () => {
     expect(RoutePath.USER_EDIT_DOG("123")).toBe("/user/dogs/123/edit");
-  });
-
-  describe("ACCOUNT_DASHBOARD ", () => {
-    it("should have a path for ADMIN accounts", () => {
-      expect(RoutePath.ACCOUNT_DASHBOARD(AccountType.ADMIN)).toBe(
-        RoutePath.ADMIN_DASHBOARD_PAGE,
-      );
-    });
-    it("should have a path for VET accounts", () => {
-      expect(RoutePath.ACCOUNT_DASHBOARD(AccountType.VET)).toBe(
-        RoutePath.VET_DASHBOARD_PAGE,
-      );
-    });
-    it("should have a path for USER accounts", () => {
-      expect(RoutePath.ACCOUNT_DASHBOARD(AccountType.USER)).toBe(
-        RoutePath.USER_DEFAULT_LOGGED_IN_PAGE,
-      );
-    });
-    it("should default to root when undefined", () => {
-      expect(RoutePath.ACCOUNT_DASHBOARD(undefined)).toBe(RoutePath.ROOT);
-    });
   });
 });


### PR DESCRIPTION
nav items
- reduced nav bar items to just visit website and visit faq

logout
- show logout in nav bar when logged-in.
- remove logout sidebar option

user sidebar
- add criteria and process options - currently dead links

root page
- redirects to user login page when not logged-in
- redirects to the account specific default landing page when logged-in

login page
- removed the cancel button (since it no longer makes sense, given the changes to root page above)

footer
- add links to admin and vet login, but only when the user is not logged-in.

Makefile
- new make all target to run all the tests
- test-ui now only uses chromium and Mobile Chome
