### PR TITLE
Bigger fonts and gaps for nav menu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,16 +28,18 @@ test:
 	npm run lint
 
 # Run playwright tests. show-report will run automatically if a test
-# fails.
+# fails. If you want to use more workers, specify pw_workers like this
+# "make pw_workers=4 test-ui".
+pw_workers=1
 .PHONY: test-ui
 test-ui: playwright-browsers
-	npx playwright test --project "Mobile Chrome" --project "chromium"
+	npx playwright test --workers $(pw_workers) --project "Mobile Chrome" --project "chromium"
 
-# Run playwright tests in headed mode, you will see flashes of
-# browser screens.
+# Like test-ui, but also adds --headed to run the tests in headed
+# mode, you will see flashes of browser screens.
 .PHONY: test-ui-headed
 test-ui-headed: playwright-browsers
-	npx playwright test --headed
+	npx playwright test --workers $(pw_workers) --project "Mobile Chrome" --project "chromium" --headed
 
 # Run playwright interactively
 .PHONY: run-playwright

--- a/e2e/nav-bar.spec.ts
+++ b/e2e/nav-bar.spec.ts
@@ -69,18 +69,36 @@ test.describe("nav bar when logged-in as user", () => {
 
 test.describe("nav bar logout flow", () => {
   test("for user", async ({ page }) => {
+    // Given logged in user
     await loginTestUser({ page });
+    const navBar = page.locator(UI_LOCATOR.NAV_BAR);
     const menuButton = page.locator(UI_LOCATOR.NAV_MENU_BUTTON);
     if (await menuButton.isVisible()) {
       await menuButton.click();
     }
-    await page
-      .locator(UI_LOCATOR.NAV_BAR)
-      .getByRole("link", { name: "Logout" })
-      .click();
-    await page.waitForURL(urlOf(RoutePath.LOGOUT_PAGE));
-    await expect(page.getByRole("button", { name: "Logout" })).toBeVisible();
-    await page.getByRole("button", { name: "Logout" }).click();
+
+    // When Logout option is selected
+    await navBar.getByRole("link", { name: "Logout" }).click();
+
+    // Then should enter the logout page
+    await expect(page).toHaveURL(urlOf(RoutePath.LOGOUT_PAGE));
+
+    // And logout button should be visible.
+    const logoutButton = page.getByRole("button", { name: "Logout" });
+    await expect(logoutButton).toBeVisible();
+
+    // And if on mobile the menu should close so the logout option should not
+    // be visible.
+    if (await menuButton.isVisible()) {
+      await expect(
+        navBar.getByRole("link", { name: "Logout" }),
+      ).not.toBeVisible();
+    }
+
+    // When logout button is clicked
+    await logoutButton.click();
+
+    // Then should return to user login page.
     await expect(page).toHaveURL(urlOf(RoutePath.USER_LOGIN_PAGE));
   });
 });

--- a/src/app/_components/header-items.tsx
+++ b/src/app/_components/header-items.tsx
@@ -10,8 +10,34 @@ import { Button } from "@/components/ui/button";
 import * as Collapsible from "@radix-ui/react-collapsible";
 import { useSession } from "next-auth/react";
 
-const MobileNav = (props: { isLoggedIn: boolean }) => {
-  const { isLoggedIn } = props;
+type NavOption = {
+  label: string;
+  href: string;
+  target?: "_blank";
+};
+
+const WEBSITE_NAV_OPTIONS: NavOption[] = [
+  {
+    label: "Visit Website",
+    href: RoutePath.WEBSITE_URL,
+    target: "_blank",
+  },
+  {
+    label: "Visit FAQ",
+    href: RoutePath.WEBSITE_FAQ_URL,
+    target: "_blank",
+  },
+];
+
+const AUTHENTICATED_OPTIONS: NavOption[] = [
+  {
+    label: "Logout",
+    href: RoutePath.LOGOUT_PAGE,
+  },
+];
+
+const MobileNav = (props: { navOptions: NavOption[] }) => {
+  const { navOptions } = props;
   const [isOpen, setIsOpen] = React.useState(false);
 
   return (
@@ -38,26 +64,21 @@ const MobileNav = (props: { isLoggedIn: boolean }) => {
         </div>
 
         <Collapsible.Content>
-          <div className="mx-4 my-2 flex flex-col gap-2">
-            <Link
-              className="text-right"
-              target="_blank"
-              href={RoutePath.WEBSITE_URL}
-            >
-              Visit Website
-            </Link>
-            <Link
-              className="text-right"
-              target="_blank"
-              href={RoutePath.WEBSITE_FAQ_URL}
-            >
-              Visit FAQ
-            </Link>
-            {isLoggedIn && (
-              <Link className="text-right" href={RoutePath.LOGOUT_PAGE}>
-                Logout
-              </Link>
-            )}
+          <div className="mx-4 my-2 flex flex-col gap-6">
+            {navOptions.map((option) => {
+              const { label, href, target } = option;
+              return (
+                <Link
+                  key={label}
+                  className="text-right text-xl"
+                  target={target}
+                  href={href}
+                  onClick={() => setIsOpen(false)}
+                >
+                  {label}
+                </Link>
+              );
+            })}
           </div>
         </Collapsible.Content>
       </Collapsible.Root>
@@ -65,8 +86,8 @@ const MobileNav = (props: { isLoggedIn: boolean }) => {
   );
 };
 
-const DesktopNav = (props: { isLoggedIn: boolean }) => {
-  const { isLoggedIn } = props;
+const DesktopNav = (props: { navOptions: NavOption[] }) => {
+  const { navOptions } = props;
   return (
     <nav className="flex h-[72px] flex-row items-center justify-between border-b bg-white shadow-lg">
       <div className="ml-8 w-[72px] flex-none">
@@ -81,17 +102,14 @@ const DesktopNav = (props: { isLoggedIn: boolean }) => {
       </div>
 
       <div className="mr-8 flex gap-8 gap-x-8">
-        <Link target="_blank" href={RoutePath.WEBSITE_URL}>
-          Visit Website
-        </Link>
-        <Link target="_blank" href={RoutePath.WEBSITE_FAQ_URL}>
-          Visit FAQ
-        </Link>
-        {isLoggedIn && (
-          <Link className="text-right" href={RoutePath.LOGOUT_PAGE}>
-            Logout
-          </Link>
-        )}
+        {navOptions.map((option) => {
+          const { label, href, target } = option;
+          return (
+            <Link key={label} target={target} href={href}>
+              {label}
+            </Link>
+          );
+        })}
       </div>
     </nav>
   );
@@ -100,14 +118,17 @@ const DesktopNav = (props: { isLoggedIn: boolean }) => {
 const HeaderItems = () => {
   const session = useSession();
   const { status } = session;
-  const isLoggedIn = status === "authenticated";
+  const isAuthenticated = status === "authenticated";
+  const navOptions: NavOption[] = isAuthenticated
+    ? [...WEBSITE_NAV_OPTIONS, ...AUTHENTICATED_OPTIONS]
+    : WEBSITE_NAV_OPTIONS;
   return (
     <div className="sticky top-0 z-10" id="bark-nav-bar">
       <div className="md:hidden">
-        <MobileNav isLoggedIn={isLoggedIn} />
+        <MobileNav navOptions={navOptions} />
       </div>
       <div className="hidden md:block">
-        <DesktopNav isLoggedIn={isLoggedIn} />
+        <DesktopNav navOptions={navOptions} />
       </div>
     </div>
   );


### PR DESCRIPTION
Changes
- use larger fonts and gaps in the nav menu so that it is easier to tap with fingers.
- close the nav menu after an option is selected
- run test-ui with 1 worker (can choose more using pw_worker=4, for example)
