### PR TITLE
Fix icon scaling in my account page

### DIFF
--- a/src/app/user/(logged-in)/my-account/page.tsx
+++ b/src/app/user/(logged-in)/my-account/page.tsx
@@ -41,6 +41,52 @@ export default async function Page() {
     timeZone: SINGAPORE_TIME_ZONE,
   });
 
+  const userDetails: {
+    key: string;
+    icon: React.ReactNode;
+    value: React.ReactNode;
+  }[] = [
+    {
+      key: "location",
+      icon: (
+        <Image
+          src={IMG_PATH.LOCATION_MARKER}
+          width={24}
+          height={26}
+          alt="location marker icon"
+          className="h-full w-auto"
+        />
+      ),
+      value: capitalize(userResidency),
+    },
+    {
+      key: "email",
+      icon: (
+        <Image
+          src={IMG_PATH.LETTER}
+          width={26}
+          height={20}
+          alt="letter icon"
+          className="h-auto w-full"
+        />
+      ),
+      value: userEmail,
+    },
+    {
+      key: "phone",
+      icon: (
+        <Image
+          src={IMG_PATH.PHONE}
+          width={30}
+          height={30}
+          alt="phone icon icon"
+          className="h-full w-auto"
+        />
+      ),
+      value: userPhoneNumber,
+    },
+  ];
+
   return (
     <main className="flex flex-col gap-6">
       <BarkH1>My Account Details</BarkH1>
@@ -56,33 +102,17 @@ export default async function Page() {
           </p>
         </div>
         <div className="flex flex-col gap-3">
-          <p className="flex items-center gap-[10px]">
-            <Image
-              src={IMG_PATH.LOCATION_MARKER}
-              width={25}
-              height={20}
-              alt="location marker icon"
-            />
-            {capitalize(userResidency)}
-          </p>
-          <p className="flex items-center gap-[10px]">
-            <Image
-              src={IMG_PATH.LETTER}
-              width={25}
-              height={20}
-              alt="letter icon"
-            />
-            {userEmail}
-          </p>
-          <p className="flex items-center gap-[10px]">
-            <Image
-              src={IMG_PATH.PHONE}
-              width={25}
-              height={20}
-              alt="phone icon icon"
-            />
-            {userPhoneNumber}
-          </p>
+          {userDetails.map((detail) => {
+            const { key, icon, value } = detail;
+            return (
+              <div key={key} className="flex items-center gap-2">
+                <div className="flex h-[25px] w-[25px] place-content-center justify-items-center">
+                  {icon}
+                </div>
+                <div>{value}</div>
+              </div>
+            );
+          })}
         </div>
       </div>
       <div className="flex flex-col gap-1">


### PR DESCRIPTION
The icons are of different shapes. Yet when we set the dimensions to the exact values from the SVG files, the alignment with the text alongside on the right goes haywire. Thus we put the icons in a 25x25 div and apply full/auto on width/height as appropriate. Now, all of these styling is very verbose. So the icons and values are put into a `userDetails` array and rendered consistently using `map()`.