### PR TITLE
Update sidebar layout to no longer add padding around main content

### DIFF
--- a/src/app/user/(logged-in)/my-account/page.tsx
+++ b/src/app/user/(logged-in)/my-account/page.tsx
@@ -88,7 +88,7 @@ export default async function Page() {
   ];
 
   return (
-    <main className="flex flex-col gap-6">
+    <main className="m-3 flex flex-col gap-6">
       <BarkH1>My Account Details</BarkH1>
 
       <div className="flex flex-col gap-2">

--- a/src/app/user/(logged-in)/my-pets/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/page.tsx
@@ -247,7 +247,7 @@ export default async function Page() {
   }
   const dogs = await getMyPets(actor);
   return (
-    <>
+    <div className="m-3">
       <div>
         {dogs.map((dog, idx, ary) => (
           <DogCard
@@ -261,6 +261,6 @@ export default async function Page() {
       <BarkButton className="mt-3 w-full" variant="brandInverse">
         Add Pet
       </BarkButton>
-    </>
+    </div>
   );
 }

--- a/src/app/user/(logged-in)/my-pets/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/page.tsx
@@ -248,16 +248,14 @@ export default async function Page() {
   const dogs = await getMyPets(actor);
   return (
     <div className="m-3">
-      <div>
-        {dogs.map((dog, idx, ary) => (
-          <DogCard
-            key={dog.dogId}
-            dog={dog}
-            cardIdx={idx}
-            isLastCard={idx === ary.length - 1}
-          />
-        ))}
-      </div>
+      {dogs.map((dog, idx, ary) => (
+        <DogCard
+          key={dog.dogId}
+          dog={dog}
+          cardIdx={idx}
+          isLastCard={idx === ary.length - 1}
+        />
+      ))}
       <BarkButton className="mt-3 w-full" variant="brandInverse">
         Add Pet
       </BarkButton>

--- a/src/components/bark/bark-sidebar.tsx
+++ b/src/components/bark/bark-sidebar.tsx
@@ -73,9 +73,7 @@ export function BarkSidebarLayout(props: {
       </div>
 
       {/* Content */}
-      <div className="w-full flex-1 px-3 py-3 md:px-[40px]">
-        {props.children}
-      </div>
+      <div className="w-full flex-1">{props.children}</div>
     </div>
   );
 }


### PR DESCRIPTION
In view of the design for /user/info, where there is a section with coloured background that's flush to the left and right sides of the page, this commit removes the padding that the sidebar layout used to place around the main content. Each page should not be responsible for adding their own padding or margins.