### PR TITLE
Fix the getAvailableDogs query

### DIFF
--- a/src/lib/vet/actions/get-available-dogs.ts
+++ b/src/lib/vet/actions/get-available-dogs.ts
@@ -57,6 +57,7 @@ async function fetchRows(actor: VetActor): Promise<Row[]> {
     SELECT dog_id
     FROM calls
     WHERE call_id NOT IN (SELECT call_id FROM reports)
+    AND call_outcome = 'APPOINTMENT'
     GROUP BY dog_id
   )
 

--- a/tests/vet/get-available-dogs.test.ts
+++ b/tests/vet/get-available-dogs.test.ts
@@ -57,6 +57,29 @@ describe("getAvailableDogs", () => {
       expect(dogs).toEqual([]);
     });
   });
+  it("should return available dog whose owner previously declined", async () => {
+    await withDb(async (dbPool) => {
+      // GIVEN
+      const { vetId } = await insertVet(1, dbPool);
+
+      // AND
+      const { availableDog, dogId } = await insertAvailableDog(
+        vetId,
+        2,
+        dbPool,
+      );
+
+      // AND
+      await insertCall(dbPool, dogId, vetId, CALL_OUTCOME.DECLINED);
+
+      // WHEN
+      const actor = getVetActor(vetId, dbPool);
+      const dogs = await getAvailableDogs(actor);
+
+      // THEN
+      expect(dogs).toEqual([availableDog]);
+    });
+  });
   it("should not return unavailable dogs", async () => {
     await withDb(async (dbPool) => {
       // GIVEN


### PR DESCRIPTION
Previously call_outcome APPOINTMENT was not considered. Thus calls with outcomes like DECLINED that would never have a report got counted as an appointment pending report. This mistake omits dogs that would otherise be available from the response.