### PR TITLE
Resolve latest weight correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ test-ui-headed: playwright-browsers
 # Run playwright interactively
 .PHONY: run-playwright
 run-playwright: playwright-browsers
-	npx playwright test --ui
+	npx playwright test --ui --project "Mobile Chrome" --project "chromium"
 
 # Installs playwright browsers
 .PHONY: playwright-browsers

--- a/db/V2__ref_tables.sql
+++ b/db/V2__ref_tables.sql
@@ -56,6 +56,10 @@ CREATE TABLE dogs (
   dog_participation_status t_participation_status NOT NULL DEFAULT 'PARTICIPATING',
   dog_pause_expiry_time TIMESTAMP WITH TIME ZONE DEFAULT NULL,
   dog_encrypted_reason TEXT NOT NULL DEFAULT '',
+
+  -- profile_modification_time is not updated by table triggers
+  profile_modification_time TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
   CONSTRAINT dog_weight_kg_is_null_or_positive CHECK (dog_weight_kg IS NULL OR dog_weight_kg > 0),
   CONSTRAINT dog_participation_check CHECK (
     (dog_participation_status = 'PARTICIPATING' AND dog_pause_expiry_time IS NULL AND dog_encrypted_reason = '' )

--- a/db/V4__ref_latest_values.sql
+++ b/db/V4__ref_latest_values.sql
@@ -102,7 +102,7 @@ CREATE VIEW latest_values AS (
         tUser.user_id,
         CASE
             WHEN tReport.visit_time IS NULL THEN tDog.dog_weight_kg
-            WHEN tReport.visit_time > tDog.dog_modification_time THEN tReport.dog_weight_kg
+            WHEN tReport.visit_time > tDog.profile_modification_time THEN tReport.dog_weight_kg
             ELSE tDog.dog_weight_kg
         END as latest_dog_weight_kg,
         tReport.dog_body_conditioning_score as latest_dog_body_conditioning_score,

--- a/db/V4__ref_latest_values.sql
+++ b/db/V4__ref_latest_values.sql
@@ -6,7 +6,8 @@ CREATE VIEW latest_values AS (
             tReport.dog_weight_kg,
             tReport.dog_body_conditioning_score,
             tReport.dog_reported_ineligibility,
-            tReport.ineligibility_expiry_time
+            tReport.ineligibility_expiry_time,
+            tReport.visit_time
         FROM (
             SELECT
                 dog_id,
@@ -99,12 +100,16 @@ CREATE VIEW latest_values AS (
     SELECT
         tDog.dog_id,
         tUser.user_id,
-        COALESCE(tLatest.dog_weight_kg, tDog.dog_weight_kg) as latest_dog_weight_kg,
-        tLatest.dog_body_conditioning_score as latest_dog_body_conditioning_score,
+        CASE
+            WHEN tReport.visit_time IS NULL THEN tDog.dog_weight_kg
+            WHEN tReport.visit_time > tDog.dog_modification_time THEN tReport.dog_weight_kg
+            ELSE tDog.dog_weight_kg
+        END as latest_dog_weight_kg,
+        tReport.dog_body_conditioning_score as latest_dog_body_conditioning_score,
         COALESCE(tHeartworm.latest_dog_heartworm_result, 'NIL') as latest_dog_heartworm_result,
         tHeartworm.latest_dog_heartworm_observation_time,
-        tLatest.dog_reported_ineligibility as latest_dog_reported_ineligibility,
-        tLatest.ineligibility_expiry_time as latest_ineligibility_expiry_time,
+        tReport.dog_reported_ineligibility as latest_dog_reported_ineligibility,
+        tReport.ineligibility_expiry_time as latest_ineligibility_expiry_time,
         CASE
             WHEN tDea1Point1.dog_dea1_point1 IS NOT NULL THEN tDea1Point1.dog_dea1_point1
             WHEN tDog.dog_dea1_point1 = 'POSITIVE' THEN 'POSITIVE'::t_pos_neg_nil
@@ -115,7 +120,7 @@ CREATE VIEW latest_values AS (
         tDonation.latest_blood_donation_time
     FROM dogs as tDog
     LEFT JOIN users as tUser on tDog.user_id = tUser.user_id
-    LEFT JOIN mLatestReports as tLatest on tDog.dog_id = tLatest.dog_id
+    LEFT JOIN mLatestReports as tReport on tDog.dog_id = tReport.dog_id
     LEFT JOIN mLatestHeartwormReports as tHeartworm on tDog.dog_id = tHeartworm.dog_id
     LEFT JOIN mLatestDea1Point1 as tDea1Point1 on tDog.dog_id = tDea1Point1.dog_id
     LEFT JOIN mAgeCalculations as tAge on tDog.dog_id = tAge.dog_id

--- a/e2e/_lib/register-test-user.ts
+++ b/e2e/_lib/register-test-user.ts
@@ -3,8 +3,7 @@ import { generateRandomGUID } from "@/lib/utilities/bark-guid";
 import { Page, expect } from "@playwright/test";
 import { urlOf, getTestBirthday } from "./e2e-test-utils";
 
-
-export async function registerTestUser(args: { page: Page; }): Promise<{
+export async function registerTestUser(args: { page: Page }): Promise<{
   guid: string;
   userName: string;
   userEmail: string;

--- a/src/lib/user/actions/update-dog-profile.ts
+++ b/src/lib/user/actions/update-dog-profile.ts
@@ -108,6 +108,7 @@ async function updateDogFields(
   const { dogEncryptedOii } = await dogMapper.mapDogOiiToDogSecureOii({
     dogName,
   });
+  // WIP: The query should set profile_modification_time to CURRENT_TIMESTAMP
   const sql = `
   UPDATE dogs
   SET

--- a/src/lib/user/actions/update-dog-profile.ts
+++ b/src/lib/user/actions/update-dog-profile.ts
@@ -108,7 +108,6 @@ async function updateDogFields(
   const { dogEncryptedOii } = await dogMapper.mapDogOiiToDogSecureOii({
     dogName,
   });
-  // WIP: The query should set profile_modification_time to CURRENT_TIMESTAMP
   const sql = `
   UPDATE dogs
   SET
@@ -119,7 +118,8 @@ async function updateDogFields(
     dog_weight_kg = $6,
     dog_dea1_point1 = $7,
     dog_ever_pregnant = $8,
-    dog_ever_received_transfusion = $9
+    dog_ever_received_transfusion = $9,
+    profile_modification_time = CURRENT_TIMESTAMP
   WHERE
     dog_id = $1
   RETURNING 1

--- a/src/lib/user/actions/update-sub-profile.ts
+++ b/src/lib/user/actions/update-sub-profile.ts
@@ -104,6 +104,7 @@ async function updateDogFields(
   const { dogEncryptedOii } = await dogMapper.mapDogOiiToDogSecureOii({
     dogName,
   });
+  // WIP: The query should set profile_modification_time to CURRENT_TIMESTAMP
   const sql = `
   UPDATE dogs
   SET

--- a/src/lib/user/actions/update-sub-profile.ts
+++ b/src/lib/user/actions/update-sub-profile.ts
@@ -104,14 +104,14 @@ async function updateDogFields(
   const { dogEncryptedOii } = await dogMapper.mapDogOiiToDogSecureOii({
     dogName,
   });
-  // WIP: The query should set profile_modification_time to CURRENT_TIMESTAMP
   const sql = `
   UPDATE dogs
   SET
     dog_encrypted_oii = $2,
     dog_weight_kg = $3,
     dog_ever_pregnant = $4,
-    dog_ever_received_transfusion = $5
+    dog_ever_received_transfusion = $5,
+    profile_modification_time = CURRENT_TIMESTAMP
   WHERE
     dog_id = $1
   RETURNING 1

--- a/tests/schema/latest-values.test.ts
+++ b/tests/schema/latest-values.test.ts
@@ -18,59 +18,9 @@ import {
   parseDateTime,
 } from "@/lib/utilities/bark-time";
 import { getAgeMonths } from "@/lib/utilities/bark-age";
-import { MILLIS_PER_WEEK } from "@/lib/utilities/bark-millis";
+import { MILLIS_PER_DAY, MILLIS_PER_WEEK } from "@/lib/utilities/bark-millis";
 
 describe("latest_values", () => {
-  const USER_IDX = 84;
-  const DOG_IDX = 42;
-  const VET_IDX = 71;
-  const DAYS = 86400000;
-
-  async function initUserOnly(dbPool: Pool): Promise<{ userId: string }> {
-    const userRecord = await insertUser(USER_IDX, dbPool);
-    const userId = userRecord.userId;
-    return { userId };
-  }
-
-  async function initDog(
-    dbPool: Pool,
-    overrides?: {
-      userSpec?: Partial<UserSpec>;
-      dogSpec?: Partial<DogSpec>;
-    },
-  ): Promise<{ userId: string; dogId: string; vetId: string }> {
-    const userRecord = await insertUser(USER_IDX, dbPool, overrides?.userSpec);
-    const userId = userRecord.userId;
-    const dogGen = await insertDog(DOG_IDX, userId, dbPool, overrides?.dogSpec);
-    const dogId = dogGen.dogId;
-    const vet = await insertVet(VET_IDX, dbPool);
-    const vetId = vet.vetId;
-    await dbInsertDogVetPreference(dbPool, dogId, vetId);
-    return { userId, dogId, vetId };
-  }
-
-  async function addReport(
-    dbPool: Pool,
-    dogId: string,
-    vetId: string,
-    overrides?: {
-      reportSpec?: Partial<DbReportSpec>;
-    },
-  ): Promise<{ reportId: string }> {
-    const { callId } = await insertCall(
-      dbPool,
-      dogId,
-      vetId,
-      CALL_OUTCOME.APPOINTMENT,
-    );
-    const { reportId } = await insertReport(
-      dbPool,
-      callId,
-      overrides?.reportSpec,
-    );
-    return { reportId };
-  }
-
   it("should not have rows for users without dogs", async () => {
     await withDb(async (dbPool) => {
       const { userId } = await initUserOnly(dbPool);
@@ -110,20 +60,75 @@ describe("latest_values", () => {
         expect(res.rows[0].latest_dog_weight_kg).toBeNull();
       });
     });
-    it("should be the value from the latest report", async () => {
+    it("should use report value when visit-time is more recent than dog-modification-time", async () => {
       await withDb(async (dbPool) => {
+        const currentTs = Date.now();
+        const oneYearAgo = new Date(currentTs - 52 * MILLIS_PER_WEEK);
+        const sixMonthsAgo = new Date(currentTs - 26 * MILLIS_PER_WEEK);
+        const lastWeek = new Date(currentTs - 1 * MILLIS_PER_WEEK);
+
+        // GIVEN record
         const { dogId, vetId } = await initDog(dbPool, {
           dogSpec: { dogWeightKg: 11.11 },
+          dogModificationTime: oneYearAgo,
         });
+
+        // AND report 1
         await addReport(dbPool, dogId, vetId, {
-          reportSpec: { dogWeightKg: 22.22 },
+          reportSpec: { dogWeightKg: 22.22, visitTime: sixMonthsAgo },
         });
+
+        // AND report 2
+        await addReport(dbPool, dogId, vetId, {
+          reportSpec: {
+            dogWeightKg: 33.33,
+            visitTime: lastWeek, // <-- most recent
+          },
+        });
+
+        // WHEN
         const res = await dbQuery(
           dbPool,
           `select latest_dog_weight_kg from latest_values where dog_id = $1`,
           [dogId],
         );
-        expect(res.rows[0].latest_dog_weight_kg).toEqual(22.22);
+
+        // THEN expect the weight from the second report
+        expect(res.rows[0].latest_dog_weight_kg).toEqual(33.33);
+      });
+    });
+    it("should use dog-record value when dog-modification-time is more recent than visit-time", async () => {
+      await withDb(async (dbPool) => {
+        const currentTs = Date.now();
+        const sixMonthsAgo = new Date(currentTs - 26 * MILLIS_PER_WEEK);
+        const lastWeek = new Date(currentTs - 1 * MILLIS_PER_WEEK);
+        const yesterday = new Date(currentTs - 1 * MILLIS_PER_DAY);
+
+        // GIVEN record
+        const { dogId, vetId } = await initDog(dbPool, {
+          dogSpec: { dogWeightKg: 11.11 },
+          dogModificationTime: yesterday, // <-- most recent
+        });
+
+        // AND report 1
+        await addReport(dbPool, dogId, vetId, {
+          reportSpec: { dogWeightKg: 22.22, visitTime: sixMonthsAgo },
+        });
+
+        // AND report 2
+        await addReport(dbPool, dogId, vetId, {
+          reportSpec: { dogWeightKg: 33.33, visitTime: lastWeek },
+        });
+
+        // WHEN
+        const res = await dbQuery(
+          dbPool,
+          `select latest_dog_weight_kg from latest_values where dog_id = $1`,
+          [dogId],
+        );
+
+        // THEN expect the weight from the dog record
+        expect(res.rows[0].latest_dog_weight_kg).toEqual(11.11);
       });
     });
   });
@@ -276,7 +281,7 @@ describe("latest_values", () => {
       await withDb(async (dbPool) => {
         // GIVEN a birthday that is slightly over 2 years and 3 months ago
         const ts = new Date().getTime();
-        const birthday = new Date(ts - (2 * 365 + 3 * 31) * DAYS);
+        const birthday = new Date(ts - (2 * 365 + 3 * 31) * MILLIS_PER_DAY);
 
         // AND a dog with that birthday
         const { dogId } = await initDog(dbPool, {
@@ -341,3 +346,67 @@ describe("latest_values", () => {
     });
   });
 });
+
+const USER_IDX = 84;
+const DOG_IDX = 42;
+const VET_IDX = 71;
+
+async function initUserOnly(dbPool: Pool): Promise<{ userId: string }> {
+  const userRecord = await insertUser(USER_IDX, dbPool);
+  const userId = userRecord.userId;
+  return { userId };
+}
+
+async function initDog(
+  dbPool: Pool,
+  overrides?: {
+    userSpec?: Partial<UserSpec>;
+    dogSpec?: Partial<DogSpec>;
+    dogModificationTime?: Date;
+  },
+): Promise<{ userId: string; dogId: string; vetId: string }> {
+  const userRecord = await insertUser(USER_IDX, dbPool, overrides?.userSpec);
+  const userId = userRecord.userId;
+  const dogGen = await insertDog(DOG_IDX, userId, dbPool, overrides?.dogSpec);
+  const dogId = dogGen.dogId;
+  const vet = await insertVet(VET_IDX, dbPool);
+  const vetId = vet.vetId;
+  await dbInsertDogVetPreference(dbPool, dogId, vetId);
+  if (overrides?.dogModificationTime !== undefined) {
+    await setDogModificationTime(dbPool, dogId, overrides.dogModificationTime);
+  }
+  return { userId, dogId, vetId };
+}
+
+async function setDogModificationTime(
+  dbPool: Pool,
+  dogId: string,
+  dogModificationTime: Date,
+) {
+  const sql = `
+  update dogs set dog_modification_time = $2 where dog_id = $1 returning 1
+  `;
+  const res = await dbQuery(dbPool, sql, [dogId, dogModificationTime]);
+}
+
+async function addReport(
+  dbPool: Pool,
+  dogId: string,
+  vetId: string,
+  overrides?: {
+    reportSpec?: Partial<DbReportSpec>;
+  },
+): Promise<{ reportId: string }> {
+  const { callId } = await insertCall(
+    dbPool,
+    dogId,
+    vetId,
+    CALL_OUTCOME.APPOINTMENT,
+  );
+  const { reportId } = await insertReport(
+    dbPool,
+    callId,
+    overrides?.reportSpec,
+  );
+  return { reportId };
+}

--- a/tests/schema/latest-values.test.ts
+++ b/tests/schema/latest-values.test.ts
@@ -97,30 +97,6 @@ describe("latest_values", () => {
           [dogId],
         );
 
-        // WIP: remove debug
-        {
-          const dogRecords = (
-            await dbQuery(
-              dbPool,
-              `select dog_modification_time from dogs where dog_id = $1`,
-              [dogId],
-            )
-          ).rows;
-          const medicalReports = (
-            await dbQuery(
-              dbPool,
-              `
-            select visit_time
-            from reports
-            where dog_id = $1
-            ORDER BY visit_time ASC
-            `,
-              [dogId],
-            )
-          ).rows;
-          console.log("WIP", { dogRecords, medicalReports });
-        }
-
         // THEN expect the weight from the second report
         expect(res.rows[0].latest_dog_weight_kg).toEqual(33.33);
       });

--- a/tests/user/get-dog-profile.test.ts
+++ b/tests/user/get-dog-profile.test.ts
@@ -16,6 +16,7 @@ import {
   DOG_ANTIGEN_PRESENCE,
   POS_NEG_NIL,
 } from "@/lib/data/db-enums";
+import { MILLIS_PER_DAY } from "@/lib/utilities/bark-millis";
 
 describe("getDogProfile", () => {
   it("should return ERROR_UNAUTHORIZED when user does not own the dog requested", async () => {
@@ -99,6 +100,7 @@ describe("getDogProfile", () => {
       const { reportId } = await insertReport(dbPool, callId, {
         dogWeightKg: 25,
         dogDea1Point1: POS_NEG_NIL.POSITIVE,
+        visitTime: new Date(Date.now() + MILLIS_PER_DAY),
       });
 
       // WHEN

--- a/tests/user/update-dog-profile.test.ts
+++ b/tests/user/update-dog-profile.test.ts
@@ -27,6 +27,8 @@ describe("updateDogProfile", () => {
       const d1 = await insertDog(1, u1.userId, dbPool);
       const v1 = await insertVet(1, dbPool);
       await dbInsertDogVetPreference(dbPool, d1.dogId, v1.vetId);
+      const { profileModificationTime: profileModificationTimeBeforeUpdate } =
+        await fetchDogInfo(dbPool, d1.dogId);
 
       // WHEN
       const v2 = await insertVet(2, dbPool);
@@ -38,8 +40,14 @@ describe("updateDogProfile", () => {
 
       // THEN
       expect(res).toEqual("OK_UPDATED");
-      const { dogProfile: registration } = await fetchDogInfo(dbPool, d1.dogId);
-      expect(registration).toEqual(update);
+      const { dogProfile, profileModificationTime } = await fetchDogInfo(
+        dbPool,
+        d1.dogId,
+      );
+      expect(dogProfile).toEqual(update);
+      expect(profileModificationTime.getTime()).toBeGreaterThan(
+        profileModificationTimeBeforeUpdate.getTime(),
+      );
     });
   });
   it("should return ERROR_REPORT_EXISTS when there is an existing report for the dog", async () => {

--- a/tests/user/update-sub-profile.test.ts
+++ b/tests/user/update-sub-profile.test.ts
@@ -28,6 +28,8 @@ describe("updateSubProfile", () => {
         CALL_OUTCOME.APPOINTMENT,
       );
       const r1 = await insertReport(dbPool, c1.callId, { dogWeightKg: 31 });
+      const { profileModificationTime: profileModificationTimeBeforeUpdate } =
+        await fetchDogInfo(dbPool, d1.dogId);
 
       // WHEN
       const v2 = await insertVet(2, dbPool);
@@ -40,8 +42,14 @@ describe("updateSubProfile", () => {
 
       // THEN
       expect(res).toEqual("OK_UPDATED");
-      const { subProfile } = await fetchDogInfo(dbPool, d1.dogId);
+      const { subProfile, profileModificationTime } = await fetchDogInfo(
+        dbPool,
+        d1.dogId,
+      );
       expect(subProfile).toEqual(update);
+      expect(profileModificationTime.getTime()).toBeGreaterThan(
+        profileModificationTimeBeforeUpdate.getTime(),
+      );
     });
   });
   it("should return ERROR_UNAUTHORIZED when user does not own the dog", async () => {

--- a/tests/user/update-sub-profile.test.ts
+++ b/tests/user/update-sub-profile.test.ts
@@ -1,13 +1,8 @@
 import { SubProfile } from "@/lib/user/user-models";
 import { withDb } from "../_db_helpers";
-import {
-  CALL_OUTCOME,
-  YES_NO_UNKNOWN,
-  YesNoUnknown,
-} from "@/lib/data/db-enums";
+import { CALL_OUTCOME, YES_NO_UNKNOWN } from "@/lib/data/db-enums";
 import {
   fetchDogInfo,
-  getDogMapper,
   getUserActor,
   insertCall,
   insertDog,
@@ -16,8 +11,6 @@ import {
   insertVet,
 } from "../_fixtures";
 import { updateSubProfile } from "@/lib/user/actions/update-sub-profile";
-import { Pool } from "pg";
-import { dbQuery } from "@/lib/data/db-utils";
 import { dbInsertDogVetPreference } from "@/lib/data/db-dogs";
 
 describe("updateSubProfile", () => {
@@ -41,7 +34,7 @@ describe("updateSubProfile", () => {
       const actor1 = getUserActor(dbPool, u1.userId);
       const update = _getSubProfile({
         dogPreferredVetId: v2.vetId,
-        dogWeightKg: 31, // TODO: Change this to 32 to test latest_values
+        dogWeightKg: 32,
       });
       const res = await updateSubProfile(actor1, d1.dogId, update);
 


### PR DESCRIPTION
(1) This commit fixes the way latest weight is resolved.

(1.1) Correct way is to use the latest value from EITHER the "dogs" table or from the "reports" table.

(1.2) The wrong way, which this fixes was to prefer the latest value from the "reports" table.

(2) To fix this, a new "profile_modification_time" column had to be added to the "dogs" table. This column defaults to CURRENT_TIMESTAMP. So it is set automatically upon insertion. Subsequently, it is updated to CURRENT_TIMESTAMP by updateDogProfile and updateSubProfile. The column is then used in the "latest_values" view to resolve the correct "latest_dog_weight_kg". (Related to barkbank-schema migrations V32 and V33.)

