### PR TITLE
Improve accessibility so iOS Safari does not zoom in on text inputs

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import BarkAuthProvider from "@/components/bark/bark-auth";
 import RootHeader from "@/app/_components/root-header";
 import RootFooter from "@/app/_components/root-footer";
+import clsx from "clsx";
 
 const siteFont = Montserrat({ subsets: ["latin"] });
 
@@ -20,7 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${siteFont.className} flex min-h-screen flex-col justify-between`}
+        className={clsx(siteFont.className, "flex min-h-screen flex-col justify-between")}
       >
         <BarkAuthProvider>
           <RootHeader />

--- a/src/components/bark/bark-form.tsx
+++ b/src/components/bark/bark-form.tsx
@@ -1,5 +1,4 @@
 import { UseFormReturn } from "react-hook-form";
-import { format } from "date-fns";
 import {
   Form,
   FormControl,

--- a/src/components/bark/bark-form.tsx
+++ b/src/components/bark/bark-form.tsx
@@ -91,7 +91,7 @@ export function BarkFormInput(props: {
           <div className="flex items-end gap-2">
             <div className="flex-grow">
               <FormControl>
-                <Input placeholder={placeholder} type={type} {...field} />
+                <Input className="text-base" placeholder={placeholder} type={type} {...field} />
               </FormControl>
             </div>
             {children}
@@ -124,7 +124,7 @@ export function BarkFormDateInput(props: {
           <FormControl>
             <Popover>
               <div className="relative">
-                <Input placeholder={placeholder} type="text" {...field} />
+                <Input className="text-base" placeholder={placeholder} type="text" {...field} />
                 <PopoverTrigger asChild>
                   <Button
                     variant={"outline"}

--- a/src/components/bark/login/bark-login-form.tsx
+++ b/src/components/bark/login/bark-login-form.tsx
@@ -14,11 +14,9 @@ import {
 import { useState } from "react";
 import { SignInResponse, signIn } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { RoutePath } from "@/lib/route-path";
 import { sendLoginOtp } from "@/lib/server-actions/send-login-otp";
 import { AccountType } from "@/lib/auth-models";
 import { FormMessage } from "@/components/ui/form";
-import Link from "next/link";
 
 const FORM_SCHEMA = z.object({
   email: z.string().email(),


### PR DESCRIPTION
(1) When the font size of a text input is under 16px, iOS Safari will zoom into the text input when it is focused. This breaks the mobile webapp experience because when the user is done entering their information, they have to manually zoom out.

(2) This commit solves the problem by using "text-base" Tailwind CSS class to set the font size to 16px. This is done for BarkFormInput and BarkFormDateInput.