### PR TITLE
User Edit Dog Page

### DIFF
--- a/e2e/_lib/pom/core/pom-dynamic-page.ts
+++ b/e2e/_lib/pom/core/pom-dynamic-page.ts
@@ -1,0 +1,11 @@
+import { PomObject } from "./pom-object";
+
+import { expect } from "@playwright/test";
+
+export abstract class PomDynamicPage extends PomObject {
+  abstract urlRegex(): RegExp;
+
+  async checkUrl() {
+    await expect(this.page()).toHaveURL(this.urlRegex());
+  }
+}

--- a/e2e/_lib/pom/core/pom-page.ts
+++ b/e2e/_lib/pom/core/pom-page.ts
@@ -1,6 +1,6 @@
 import { PomObject } from "./pom-object";
 
-import { expect, Locator } from "@playwright/test";
+import { expect } from "@playwright/test";
 
 export abstract class PomPage extends PomObject {
   abstract url(): string;

--- a/e2e/_lib/pom/init/register-test-user.ts
+++ b/e2e/_lib/pom/init/register-test-user.ts
@@ -14,6 +14,8 @@ export async function registerTestUser(args: { page: Page }): Promise<{
   userPhoneNumber: string;
   dogName: string;
   dogBreed: string;
+  dogBirthday: string;
+  dogWeightKg: string;
   userMyPetsPage: UserMyPetsPage;
 }> {
   const guid = generateRandomGUID(8);
@@ -22,6 +24,8 @@ export async function registerTestUser(args: { page: Page }): Promise<{
   const userPhoneNumber = guid;
   const dogName = `Bob (${guid})`;
   const dogBreed = "REGISTERED DOG";
+  const dogBirthday = getTestBirthday(5);
+  const dogWeightKg = "31.4";
 
   const { page } = args;
   const context = await initPomContext({ page });
@@ -34,9 +38,9 @@ export async function registerTestUser(args: { page: Page }): Promise<{
   // Pet Form
   await page.getByLabel("What's your dog's name?").fill(dogName);
   await page.getByLabel("What's your dog's breed?").fill(dogBreed);
-  await page.locator('input[name="dogBirthday"]').fill(getTestBirthday(5));
+  await page.locator('input[name="dogBirthday"]').fill(dogBirthday);
   await page.getByRole("button", { name: "Male", exact: true }).click();
-  await page.getByLabel("What's your dog's weight? (KG)").fill("31.4");
+  await page.getByLabel("What's your dog's weight? (KG)").fill(dogWeightKg);
   await page
     .getByText("Do you know it's blood type?I")
     .getByLabel("I don't know")
@@ -81,6 +85,8 @@ export async function registerTestUser(args: { page: Page }): Promise<{
     userPhoneNumber,
     dogName,
     dogBreed,
+    dogBirthday,
+    dogWeightKg,
     userMyPetsPage,
   };
   console.log(result);

--- a/e2e/_lib/pom/pages/user-edit-dog-page.ts
+++ b/e2e/_lib/pom/pages/user-edit-dog-page.ts
@@ -1,8 +1,68 @@
 import { RoutePath } from "@/lib/route-path";
 import { PomDynamicPage } from "../core/pom-dynamic-page";
+import { Locator } from "@playwright/test";
 
 export class UserEditDogPage extends PomDynamicPage {
   urlRegex(): RegExp {
     return RoutePath.USER_EDIT_DOG_REGEX;
+  }
+
+  dogNameField(): Locator {
+    return this.page().getByLabel('Name');
+  }
+
+  dogBreedField(): Locator {
+    return this.page().getByLabel('Breed');
+  }
+
+  dogBirthdayField(): Locator {
+    return this.page().locator('input[name="dogBirthday"]');
+  }
+
+  dogWeightField(): Locator {
+    return this.page().getByLabel("Weight");
+  }
+
+  dogGenderOption_MALE(): Locator {
+    return this.page()
+      .getByText("Sex", { exact: true })
+      .locator("..")
+      .getByLabel("Male", { exact: true });
+  }
+
+  dogBloodTypeOption_UNKNOWN(): Locator {
+    return this.page()
+      .getByText("Blood Type")
+      .locator("..")
+      .getByLabel("I don't know");
+  }
+
+  dogEverReceivedTransfusionOption_NO(): Locator {
+    return this.page()
+      .getByText("Ever Received Blood Transfusion", { exact: true })
+      .locator("..")
+      .getByLabel("No", { exact: true });
+  }
+
+  dogEverPregnantOption_NO(): Locator {
+    return this.page()
+      .getByText("Ever Pregnant", { exact: true })
+      .locator("..")
+      .getByLabel("No", { exact: true });
+  }
+
+  dogPreferredVetOption_1(): Locator {
+    return this.page()
+      .getByText("Preferred Donation Point", { exact: true })
+      .locator("..")
+      .getByLabel("Vet Clinic 1", { exact: true });
+  }
+
+  saveButton(): Locator {
+    return this.page().getByRole("button", { name: "Save" });
+  }
+
+  cancelButton(): Locator {
+    return this.page().getByRole("button", { name: "Cancel" });
   }
 }

--- a/e2e/_lib/pom/pages/user-edit-dog-page.ts
+++ b/e2e/_lib/pom/pages/user-edit-dog-page.ts
@@ -1,0 +1,8 @@
+import { RoutePath } from "@/lib/route-path";
+import { PomDynamicPage } from "../core/pom-dynamic-page";
+
+export class UserEditDogPage extends PomDynamicPage {
+  urlRegex(): RegExp {
+    return RoutePath.USER_EDIT_DOG_REGEX;
+  }
+}

--- a/e2e/_lib/pom/pages/user-edit-dog-page.ts
+++ b/e2e/_lib/pom/pages/user-edit-dog-page.ts
@@ -8,11 +8,11 @@ export class UserEditDogPage extends PomDynamicPage {
   }
 
   dogNameField(): Locator {
-    return this.page().getByLabel('Name');
+    return this.page().getByLabel("Name");
   }
 
   dogBreedField(): Locator {
-    return this.page().getByLabel('Breed');
+    return this.page().getByLabel("Breed");
   }
 
   dogBirthdayField(): Locator {

--- a/e2e/_lib/pom/pages/user-my-pets-page.ts
+++ b/e2e/_lib/pom/pages/user-my-pets-page.ts
@@ -38,7 +38,7 @@ export class DogCardItem extends PomComponent {
   }
 
   public editButton(): Locator {
-    return this.locator().getByRole("button", { name: "Edit" });
+    return this.locator().getByRole("link", { name: "Edit" });
   }
 
   public viewButton(): Locator {

--- a/e2e/user/user-can-cancel-edit-dog.spec.ts
+++ b/e2e/user/user-can-cancel-edit-dog.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test";
+import { registerTestUser } from "../_lib/pom/init/register-test-user";
+import { UserMyPetsPage } from "../_lib/pom/pages/user-my-pets-page";
+import { UserEditDogPage } from "../_lib/pom/pages/user-edit-dog-page";
+
+test("user can cancel edit dog profile", async ({ page }) => {
+  const { context, dogName, dogBreed, dogBirthday, dogWeightKg } =
+    await registerTestUser({ page });
+
+  const pg1 = new UserMyPetsPage(context);
+  await pg1.checkUrl();
+  const pg1card = pg1.dogCardItem(dogName);
+  await expect(pg1card.locator()).toBeVisible();
+  await expect(pg1card.editButton()).toBeVisible();
+  await pg1card.editButton().click();
+
+  const pg2 = new UserEditDogPage(context);
+  await pg2.checkUrl();
+  await expect(pg2.dogNameField()).toHaveValue(dogName);
+  await expect(pg2.dogBreedField()).toHaveValue(dogBreed);
+  await expect(pg2.dogBirthdayField()).toHaveValue(dogBirthday);
+  await expect(pg2.dogWeightField()).toHaveValue(dogWeightKg);
+  await expect(pg2.saveButton()).toBeVisible();
+  await pg2.dogNameField().fill("Thomas Green");
+  await pg2.dogBreedField().fill("Royal Canine");
+  await pg2.dogBirthdayField().fill("1968-08-28");
+  await pg2.dogWeightField().fill("16.827");
+
+  // BUT cancelled
+  await pg2.cancelButton().click();
+
+  const pg3 = new UserMyPetsPage(context);
+  await pg3.checkUrl();
+  const pg3card = pg3.dogCardItem(dogName);
+  await expect(pg3card.locator()).toBeVisible();
+  await expect(pg3card.editButton()).toBeVisible();
+  await pg3card.editButton().click();
+
+  const pg4 = new UserEditDogPage(context);
+  await pg4.checkUrl();
+  await expect(pg4.dogNameField()).toHaveValue(dogName);
+  await expect(pg4.dogBreedField()).toHaveValue(dogBreed);
+  await expect(pg4.dogBirthdayField()).toHaveValue(dogBirthday);
+  await expect(pg4.dogWeightField()).toHaveValue(dogWeightKg);
+});

--- a/e2e/user/user-can-edit-dog.spec.ts
+++ b/e2e/user/user-can-edit-dog.spec.ts
@@ -40,4 +40,6 @@ test("user can edit dog profile", async ({ page }) => {
   await expect(pg4.dogBreedField()).toHaveValue("Royal Canine");
   await expect(pg4.dogBirthdayField()).toHaveValue("1968-08-28");
   await expect(pg4.dogWeightField()).toHaveValue("16.827");
+
+  // TODO: In future, also check the UserViewDogPage.
 });

--- a/e2e/user/user-can-edit-dog.spec.ts
+++ b/e2e/user/user-can-edit-dog.spec.ts
@@ -4,16 +4,41 @@ import { UserMyPetsPage } from "../_lib/pom/pages/user-my-pets-page";
 import { UserEditDogPage } from "../_lib/pom/pages/user-edit-dog-page";
 
 test("user can edit dog profile", async ({ page }) => {
-  const { context, dogName, dogBreed } = await registerTestUser({ page });
+  const { context, dogName, dogBreed, dogBirthday, dogWeightKg } =
+    await registerTestUser({ page });
 
   const pg1 = new UserMyPetsPage(context);
   await pg1.checkUrl();
 
-  const card = pg1.dogCardItem(dogName);
-  expect(card.locator()).toBeVisible();
-  expect(card.editButton()).toBeVisible();
-  await card.editButton().click();
+  const card1 = pg1.dogCardItem(dogName);
+  await expect(card1.locator()).toBeVisible();
+  await expect(card1.editButton()).toBeVisible();
+  await card1.editButton().click();
 
   const pg2 = new UserEditDogPage(context);
   await pg2.checkUrl();
+  await expect(pg2.dogNameField()).toHaveValue(dogName);
+  await expect(pg2.dogBreedField()).toHaveValue(dogBreed);
+  await expect(pg2.dogBirthdayField()).toHaveValue(dogBirthday);
+  await expect(pg2.dogWeightField()).toHaveValue(dogWeightKg);
+  await expect(pg2.saveButton()).toBeVisible();
+  await pg2.dogNameField().fill("Thomas Green");
+  await pg2.dogBreedField().fill("Royal Canine");
+  await pg2.dogBirthdayField().fill("1968-08-28");
+  await pg2.dogWeightField().fill("16.827");
+  await pg2.saveButton().click();
+
+  const pg3 = new UserMyPetsPage(context);
+  await pg3.checkUrl();
+  const card3 = pg3.dogCardItem("Thomas Green");
+  await expect(card3.locator()).toBeVisible();
+  await expect(card3.editButton()).toBeVisible();
+  await card3.editButton().click();
+
+  const pg4 = new UserEditDogPage(context);
+  await pg4.checkUrl();
+  await expect(pg4.dogBreedField()).toHaveValue("Royal Canine");
+  await expect(pg2.dogBreedField()).toHaveValue("Royal Canine");
+  await expect(pg2.dogBirthdayField()).toHaveValue("1968-08-28");
+  await expect(pg2.dogWeightField()).toHaveValue("16.827");
 });

--- a/e2e/user/user-can-edit-dog.spec.ts
+++ b/e2e/user/user-can-edit-dog.spec.ts
@@ -37,7 +37,7 @@ test("user can edit dog profile", async ({ page }) => {
 
   const pg4 = new UserEditDogPage(context);
   await pg4.checkUrl();
-  await expect(pg4.dogBreedField()).toHaveValue("Royal Canine");
+  await expect(pg4.dogNameField()).toHaveValue("Thomas Green");
   await expect(pg2.dogBreedField()).toHaveValue("Royal Canine");
   await expect(pg2.dogBirthdayField()).toHaveValue("1968-08-28");
   await expect(pg2.dogWeightField()).toHaveValue("16.827");

--- a/e2e/user/user-can-edit-dog.spec.ts
+++ b/e2e/user/user-can-edit-dog.spec.ts
@@ -9,11 +9,10 @@ test("user can edit dog profile", async ({ page }) => {
 
   const pg1 = new UserMyPetsPage(context);
   await pg1.checkUrl();
-
-  const card1 = pg1.dogCardItem(dogName);
-  await expect(card1.locator()).toBeVisible();
-  await expect(card1.editButton()).toBeVisible();
-  await card1.editButton().click();
+  const pg1card = pg1.dogCardItem(dogName);
+  await expect(pg1card.locator()).toBeVisible();
+  await expect(pg1card.editButton()).toBeVisible();
+  await pg1card.editButton().click();
 
   const pg2 = new UserEditDogPage(context);
   await pg2.checkUrl();
@@ -30,15 +29,15 @@ test("user can edit dog profile", async ({ page }) => {
 
   const pg3 = new UserMyPetsPage(context);
   await pg3.checkUrl();
-  const card3 = pg3.dogCardItem("Thomas Green");
-  await expect(card3.locator()).toBeVisible();
-  await expect(card3.editButton()).toBeVisible();
-  await card3.editButton().click();
+  const pg3card = pg3.dogCardItem("Thomas Green");
+  await expect(pg3card.locator()).toBeVisible();
+  await expect(pg3card.editButton()).toBeVisible();
+  await pg3card.editButton().click();
 
   const pg4 = new UserEditDogPage(context);
   await pg4.checkUrl();
   await expect(pg4.dogNameField()).toHaveValue("Thomas Green");
-  await expect(pg2.dogBreedField()).toHaveValue("Royal Canine");
-  await expect(pg2.dogBirthdayField()).toHaveValue("1968-08-28");
-  await expect(pg2.dogWeightField()).toHaveValue("16.827");
+  await expect(pg4.dogBreedField()).toHaveValue("Royal Canine");
+  await expect(pg4.dogBirthdayField()).toHaveValue("1968-08-28");
+  await expect(pg4.dogWeightField()).toHaveValue("16.827");
 });

--- a/e2e/user/user-can-edit-dog.spec.ts
+++ b/e2e/user/user-can-edit-dog.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from "@playwright/test";
+import { registerTestUser } from "../_lib/pom/init/register-test-user";
+import { UserMyPetsPage } from "../_lib/pom/pages/user-my-pets-page";
+import { UserEditDogPage } from "../_lib/pom/pages/user-edit-dog-page";
+
+test("user can edit dog profile", async ({ page }) => {
+  const { context, dogName, dogBreed } = await registerTestUser({ page });
+
+  const pg1 = new UserMyPetsPage(context);
+  await pg1.checkUrl();
+
+  const card = pg1.dogCardItem(dogName);
+  expect(card.locator()).toBeVisible();
+  expect(card.editButton()).toBeVisible();
+  await card.editButton().click();
+
+  const pg2 = new UserEditDogPage(context);
+  await pg2.checkUrl();
+});

--- a/src/app/user/(logged-in)/my-pets/add-dog/_actions/submit-dog.ts
+++ b/src/app/user/(logged-in)/my-pets/add-dog/_actions/submit-dog.ts
@@ -16,7 +16,7 @@ export async function submitDog(
   }
   const res = await addMyDog(actor, dogProfile);
   if (res.error === undefined) {
-    revalidatePath(RoutePath.USER_MY_PETS, "page");
+    revalidatePath(RoutePath.USER_MY_PETS, "layout");
   }
   return res;
 }

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/update-dog-profile-action.ts
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/update-dog-profile-action.ts
@@ -1,6 +1,10 @@
+"use server";
+
 import { getAuthenticatedUserActor } from "@/lib/auth";
+import { RoutePath } from "@/lib/route-path";
 import { updateDogProfile } from "@/lib/user/actions/update-dog-profile";
 import { DogProfile } from "@/lib/user/user-models";
+import { revalidatePath } from "next/cache";
 
 type ResponseCode =
   | "ERROR_NOT_LOGGED_IN"
@@ -20,5 +24,8 @@ export async function updateDogProfileAction(args: {
     return "ERROR_NOT_LOGGED_IN";
   }
   const res = await updateDogProfile(actor, dogId, dogProfile);
+  if (res === "OK_UPDATED") {
+    revalidatePath(RoutePath.USER_MY_PETS, "page");
+  }
   return res;
 }

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/update-dog-profile-action.ts
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/update-dog-profile-action.ts
@@ -25,7 +25,7 @@ export async function updateDogProfileAction(args: {
   }
   const res = await updateDogProfile(actor, dogId, dogProfile);
   if (res === "OK_UPDATED") {
-    revalidatePath(RoutePath.USER_MY_PETS, "page");
+    revalidatePath(RoutePath.USER_MY_PETS, "layout");
   }
   return res;
 }

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/update-dog-profile-action.ts
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/update-dog-profile-action.ts
@@ -1,0 +1,24 @@
+import { getAuthenticatedUserActor } from "@/lib/auth";
+import { updateDogProfile } from "@/lib/user/actions/update-dog-profile";
+import { DogProfile } from "@/lib/user/user-models";
+
+type ResponseCode =
+  | "ERROR_NOT_LOGGED_IN"
+  | "OK_UPDATED"
+  | "ERROR_UNAUTHORIZED"
+  | "ERROR_REPORT_EXISTS"
+  | "ERROR_MISSING_DOG"
+  | "FAILURE_DB_UPDATE";
+
+export async function updateDogProfileAction(args: {
+  dogId: string;
+  dogProfile: DogProfile;
+}): Promise<ResponseCode> {
+  const { dogId, dogProfile } = args;
+  const actor = await getAuthenticatedUserActor();
+  if (actor === null) {
+    return "ERROR_NOT_LOGGED_IN";
+  }
+  const res = await updateDogProfile(actor, dogId, dogProfile);
+  return res;
+}

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_components/edit-dog-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_components/edit-dog-profile-form.tsx
@@ -47,7 +47,7 @@ export default function EditDogProfileForm(props: {
 
   return (
     <GeneralDogForm
-      formTitle="Add Dog"
+      formTitle="Edit Dog"
       vetOptions={vetOptions}
       handleSubmit={handleValues}
       handleCancel={handleCancel}

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_components/edit-dog-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_components/edit-dog-profile-form.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { BarkFormOption } from "@/components/bark/bark-form";
+import { DogProfile } from "@/lib/user/user-models";
+import {
+  UTC_DATE_OPTION,
+  formatDateTime,
+  parseDateTime,
+} from "@/lib/utilities/bark-time";
+import { useRouter } from "next/navigation";
+import { RoutePath } from "@/lib/route-path";
+import { Err, Ok, Result } from "@/lib/utilities/result";
+import GeneralDogForm, {
+  DogFormData,
+} from "../../../../_components/general-dog-form";
+import { updateDogProfileAction } from "../_actions/update-dog-profile-action";
+
+export default function EditDogProfileForm(props: {
+  vetOptions: BarkFormOption[];
+  dogId: string;
+  existingDogProfile: DogProfile;
+}) {
+  const router = useRouter();
+  const { vetOptions, dogId, existingDogProfile } = props;
+
+  async function handleValues(
+    values: DogFormData,
+  ): Promise<Result<true, string>> {
+    const dogProfile = toDogProfile(values);
+    const res = await updateDogProfileAction({ dogId, dogProfile });
+    if (res === "ERROR_NOT_LOGGED_IN") {
+      router.push(RoutePath.USER_LOGIN_PAGE);
+      return Err(res);
+    }
+    if (res !== "OK_UPDATED") {
+      return Err(res);
+    }
+    router.push(RoutePath.USER_MY_PETS);
+    return Ok(true);
+  }
+
+  async function handleCancel() {
+    router.push(RoutePath.USER_MY_PETS);
+  }
+
+  const prefillData = toDogFormData(existingDogProfile);
+
+  return (
+    <GeneralDogForm
+      formTitle="Add Dog"
+      vetOptions={vetOptions}
+      handleSubmit={handleValues}
+      handleCancel={handleCancel}
+      prefillData={prefillData}
+    />
+  );
+}
+
+function toDogFormData(dogProfile: DogProfile): DogFormData {
+  const { dogBirthday, dogWeightKg, ...otherFields } = dogProfile;
+  const dogBirthdayString = formatDateTime(dogBirthday, UTC_DATE_OPTION);
+  const dogWeightKgString = dogWeightKg !== null ? dogWeightKg.toString() : "";
+  const dogFormData: DogFormData = {
+    dogBirthday: dogBirthdayString,
+    dogWeightKg: dogWeightKgString,
+    ...otherFields,
+  };
+  return dogFormData;
+}
+
+function toDogProfile(dogFormData: DogFormData): DogProfile {
+  const {
+    dogBirthday: dogBirthdayString,
+    dogWeightKg: dogWeightKgString,
+    ...otherFields
+  } = dogFormData;
+  const dogBirthday = parseDateTime(dogBirthdayString, UTC_DATE_OPTION);
+  const dogWeightKg = parseFloat(dogWeightKgString);
+  const dogProfile: DogProfile = {
+    dogBirthday,
+    dogWeightKg,
+    ...otherFields,
+  };
+  return dogProfile;
+}

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/page.tsx
@@ -1,0 +1,13 @@
+import { BarkButton } from "@/components/bark/bark-button";
+import { BarkH1 } from "@/components/bark/bark-typography";
+import { RoutePath } from "@/lib/route-path";
+
+export default async function Page(props: { params: {dogId: string}}) {
+  const {params: {dogId}} = props;
+  return (
+    <div className="p-3">
+      <BarkH1>Edit Dog {dogId}</BarkH1>
+      <BarkButton variant="brandInverse" href={RoutePath.USER_MY_PETS}>Back</BarkButton>
+    </div>
+  );
+}

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/page.tsx
@@ -1,17 +1,39 @@
-import { BarkButton } from "@/components/bark/bark-button";
-import { BarkH1 } from "@/components/bark/bark-typography";
+"use server";
+
 import { RoutePath } from "@/lib/route-path";
+import EditDogProfileForm from "./_components/edit-dog-profile-form";
+import APP from "@/lib/app";
+import { getVetFormOptions } from "@/app/_lib/get-vet-form-options";
+import { getAuthenticatedUserActor } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { getDogProfile } from "@/lib/user/actions/get-dog-profile";
 
 export default async function Page(props: { params: { dogId: string } }) {
   const {
     params: { dogId },
   } = props;
+
+  const actor = await getAuthenticatedUserActor();
+  if (actor === null) {
+    redirect(RoutePath.USER_LOGIN_PAGE);
+  }
+  const { result: existingDogProfile, error } = await getDogProfile(
+    actor,
+    dogId,
+  );
+  if (error) {
+    redirect(RoutePath.USER_MY_PETS);
+  }
+
+  const vetOptions = await APP.getDbPool().then(getVetFormOptions);
+
   return (
-    <div className="p-3">
-      <BarkH1>Edit Dog {dogId}</BarkH1>
-      <BarkButton variant="brandInverse" href={RoutePath.USER_MY_PETS}>
-        Back
-      </BarkButton>
+    <div className="m-3">
+      <EditDogProfileForm
+        vetOptions={vetOptions}
+        dogId={dogId}
+        existingDogProfile={existingDogProfile}
+      />
     </div>
   );
 }

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/page.tsx
@@ -2,12 +2,16 @@ import { BarkButton } from "@/components/bark/bark-button";
 import { BarkH1 } from "@/components/bark/bark-typography";
 import { RoutePath } from "@/lib/route-path";
 
-export default async function Page(props: { params: {dogId: string}}) {
-  const {params: {dogId}} = props;
+export default async function Page(props: { params: { dogId: string } }) {
+  const {
+    params: { dogId },
+  } = props;
   return (
     <div className="p-3">
       <BarkH1>Edit Dog {dogId}</BarkH1>
-      <BarkButton variant="brandInverse" href={RoutePath.USER_MY_PETS}>Back</BarkButton>
+      <BarkButton variant="brandInverse" href={RoutePath.USER_MY_PETS}>
+        Back
+      </BarkButton>
     </div>
   );
 }

--- a/src/app/user/(logged-in)/my-pets/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/page.tsx
@@ -196,7 +196,11 @@ function ActionBlock(props: { dog: MyDog }) {
   }
   return (
     <div className="flex flex-col gap-3">
-      <BarkButton variant="brandInverse" className="w-full" href={RoutePath.USER_EDIT_DOG(dogId)}>
+      <BarkButton
+        variant="brandInverse"
+        className="w-full"
+        href={RoutePath.USER_EDIT_DOG(dogId)}
+      >
         Edit
       </BarkButton>
       <BarkButton variant="brandInverse" className="w-full">

--- a/src/app/user/(logged-in)/my-pets/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/page.tsx
@@ -185,6 +185,7 @@ function StatusBlock(props: { dog: MyDog }) {
 
 function ActionBlock(props: { dog: MyDog }) {
   const { dog } = props;
+  const { dogId } = dog;
   const highlightedStatus = mapStatusSetToHighlightedStatus(toStatusSet(dog));
   if (highlightedStatus === PROFILE_STATUS.INCOMPLETE) {
     return (
@@ -195,7 +196,7 @@ function ActionBlock(props: { dog: MyDog }) {
   }
   return (
     <div className="flex flex-col gap-3">
-      <BarkButton variant="brandInverse" className="w-full">
+      <BarkButton variant="brandInverse" className="w-full" href={RoutePath.USER_EDIT_DOG(dogId)}>
         Edit
       </BarkButton>
       <BarkButton variant="brandInverse" className="w-full">

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-base font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
   {
     variants: {
       variant: {

--- a/src/lib/route-path.ts
+++ b/src/lib/route-path.ts
@@ -10,8 +10,10 @@ export class RoutePath {
   static readonly USER_ADD_DOG = "/user/my-pets/add-dog";
   static readonly USER_MY_ACCOUNT_EDIT = "/user/my-account/edit";
   static readonly USER_MY_ACCOUNT_PAGE = "/user/my-account";
-  static readonly USER_VIEW_DOG = (dogId: string) => `/user/my-pets/dogs/${dogId}`;
-  static readonly USER_EDIT_DOG = (dogId: string) => `/user/my-pets/dogs/${dogId}/edit`;
+  static readonly USER_VIEW_DOG = (dogId: string) =>
+    `/user/my-pets/dogs/${dogId}`;
+  static readonly USER_EDIT_DOG = (dogId: string) =>
+    `/user/my-pets/dogs/${dogId}/edit`;
   static readonly USER_CRITERIA = "/user/criteria";
   static readonly USER_PROCESS = "/user/process";
 

--- a/src/lib/route-path.ts
+++ b/src/lib/route-path.ts
@@ -10,8 +10,8 @@ export class RoutePath {
   static readonly USER_ADD_DOG = "/user/my-pets/add-dog";
   static readonly USER_MY_ACCOUNT_EDIT = "/user/my-account/edit";
   static readonly USER_MY_ACCOUNT_PAGE = "/user/my-account";
-  static readonly USER_VIEW_DOG = (dogId: string) => `/user/dogs/${dogId}`;
-  static readonly USER_EDIT_DOG = (dogId: string) => `/user/dogs/${dogId}/edit`;
+  static readonly USER_VIEW_DOG = (dogId: string) => `/user/my-pets/dogs/${dogId}`;
+  static readonly USER_EDIT_DOG = (dogId: string) => `/user/my-pets/dogs/${dogId}/edit`;
   static readonly USER_CRITERIA = "/user/criteria";
   static readonly USER_PROCESS = "/user/process";
 

--- a/src/lib/route-path.ts
+++ b/src/lib/route-path.ts
@@ -14,6 +14,8 @@ export class RoutePath {
     `/user/my-pets/dogs/${dogId}`;
   static readonly USER_EDIT_DOG = (dogId: string) =>
     `/user/my-pets/dogs/${dogId}/edit`;
+  static readonly USER_EDIT_DOG_REGEX =
+    /.*[/]user[/]my-pets[/]dogs[/][0-9]+[/]edit/;
   static readonly USER_CRITERIA = "/user/criteria";
   static readonly USER_PROCESS = "/user/process";
 

--- a/tests/RoutePath.test.ts
+++ b/tests/RoutePath.test.ts
@@ -5,9 +5,9 @@ describe("RoutePath", () => {
     expect(RoutePath.ROOT).toBe("/");
   });
   it("should have a path for USER_VIEW_DOG(dogId)", () => {
-    expect(RoutePath.USER_VIEW_DOG("123")).toBe("/user/dogs/123");
+    expect(RoutePath.USER_VIEW_DOG("123")).toBe("/user/my-pets/dogs/123");
   });
   it("should have a path for USER_EDIT_DOG(dogId)", () => {
-    expect(RoutePath.USER_EDIT_DOG("123")).toBe("/user/dogs/123/edit");
+    expect(RoutePath.USER_EDIT_DOG("123")).toBe("/user/my-pets/dogs/123/edit");
   });
 });


### PR DESCRIPTION
(1) This commit implements the User Edit Dog Page.

(2) Details about the implementation:

-(a) It is built on the GeneralDogForm.

-(b) Pre-filled data is taken from getDogProfile.

(3) Other changes:

-(a) A PomDynamicPage abstraction was introduced for pages like Edit Dog where the URL is a dynamic route.

-(b) Route paths for edit and view dog were updated to include "my-pets". This way the navigation component can mark the correct nav-route as active.

-(c) revalidatePath for My Pets is now done at the "layout" level (Ref1). The reason for this is so that My Pets and View Dog can be revalidated. At least I think this is how it works. We should update the Edit Dog test to verify this. A TODO comment is left in the test to check this in future.

Ref1: https://nextjs.org/docs/app/api-reference/functions/revalidatePath
