### PR TITLE
test visitor-can-register

### DIFF
--- a/.github/workflows/test-ui.yml
+++ b/.github/workflows/test-ui.yml
@@ -7,6 +7,11 @@ on:
   pull_request:
 jobs:
   test-ui:
+    strategy:
+      matrix:
+        project:
+          - Mobile Chrome
+          - chromium
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -39,18 +44,22 @@ jobs:
       - name: run migrations
         run: flyway -url=jdbc:postgresql://localhost:5800/postgres -locations=db -user=postgres -password=password migrate
 
+      - name: slugify project name
+        id: slugify
+        run: echo "project=$(echo ${{matrix.project}} | tr '[:upper:]' '[:lower:]' | tr ' ' '-')" >> $GITHUB_OUTPUT
+
       - name: test
         run: |
           cat env.template > .env.local
           npm run dev &
           sleep 5
           npx node scripts/setup-dev-data.js
-          npx playwright test --project "Mobile Chrome" --project "chromium"
+          npx playwright test --project "${{matrix.project}}"
 
       - name: save playwright report
         uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}
         with:
-          name: playwright-report
+          name: playwright-report-for-${{steps.slugify.outputs.project}}
           path: playwright-report/
           retention-days: 30

--- a/e2e/_lib/pom/init/register-test-user.ts
+++ b/e2e/_lib/pom/init/register-test-user.ts
@@ -5,6 +5,7 @@ import { getTestBirthday } from "../../e2e-test-utils";
 import { initPomContext } from "./init-pom-context";
 import { UserMyPetsPage } from "../pages/user-my-pets-page";
 import { PomContext } from "../core/pom-object";
+import { UserRegistrationPage } from "../pages/user-registration-page";
 
 export async function registerTestUser(args: { page: Page }): Promise<{
   context: PomContext;
@@ -30,53 +31,38 @@ export async function registerTestUser(args: { page: Page }): Promise<{
   const { page } = args;
   const context = await initPomContext({ page });
 
-  await page.goto(context.website.urlOf(RoutePath.USER_REGISTRATION));
-  await expect(page).toHaveURL(
-    context.website.urlOf(RoutePath.USER_REGISTRATION),
-  );
+  const pg = new UserRegistrationPage(context);
+  await page.goto(pg.url());
+  await pg.checkUrl();
 
   // Pet Form
-  await page.getByLabel("What's your dog's name?").fill(dogName);
-  await page.getByLabel("What's your dog's breed?").fill(dogBreed);
-  await page.locator('input[name="dogBirthday"]').fill(dogBirthday);
-  await page.getByRole("button", { name: "Male", exact: true }).click();
-  await page.getByLabel("What's your dog's weight? (KG)").fill(dogWeightKg);
-  await page
-    .getByText("Do you know it's blood type?I")
-    .getByLabel("I don't know")
-    .click();
-  await page
-    .getByText("Has it received blood transfusion before?I don't knowYesNo")
-    .locator('[id="\\:R11rrrqkq\\:-form-item"]')
-    .getByRole("button", { name: "No", exact: true })
-    .click();
-  await page
-    .getByText("Has your dog been pregnant before?I don't knowYesNo")
-    .locator('[id="\\:R15rrrqkq\\:-form-item"]')
-    .getByRole("button", { name: "No", exact: true })
-    .click();
-  await page.getByLabel("Vet Clinic 1").click();
-  await page.getByRole("button", { name: "Next" }).click();
+  await pg.dogNameField().fill(dogName);
+  await pg.dogBreedField().fill(dogBreed);
+  await pg.dogBirthdayField().fill(dogBirthday);
+  await pg.dogGender_MALE().click();
+  await pg.dogWeightField().fill(dogWeightKg);
+  await pg.dogBloodType_UNKNOWN().click();
+  await pg.dogEverReceivedTransfusion_NO().click();
+  await pg.dogEverPregnant_NO().click();
+  await pg.dogPreferredVet_VetClinic1().click();
+  await pg.nextButton().click();
 
   // Human Form
-  await page
-    .getByText("Are you currently based in Singapore?YesNo")
-    .getByRole("button", { name: "Yes" })
-    .click();
-  await page.getByLabel("How would you like to be").fill(userName);
-  await page.getByLabel("What number can we reach you").fill(userPhoneNumber);
-  await page.getByLabel("Please provide a login email").fill(userEmail);
-  await page.getByLabel("Enter OTP").fill("000000");
-  await page.getByLabel("Disclaimer").click();
-  await page.getByRole("button", { name: "Submit" }).click();
+  await pg.userResidency_SINGAPORE().click();
+  await pg.userNameField().fill(userName);
+  await pg.userPhoneNumberField().fill(userPhoneNumber);
+  await pg.userEmailField().fill(userEmail);
+  await pg.otpField().fill("000000");
+  await pg.disclaimerCheckbox().click();
+  await pg.submitButton().click();
 
   // Final
-  await page.getByRole("button", { name: "Enter My Dashboard" }).click();
-  await expect(page).toHaveURL(
-    context.website.urlOf(RoutePath.USER_DEFAULT_LOGGED_IN_PAGE),
-  );
+  await pg.enterDashboardButton().click();
+
+  // Should be at my pets
   const userMyPetsPage = new UserMyPetsPage(context);
   await userMyPetsPage.checkUrl();
+
   const result = {
     context,
     guid,

--- a/e2e/_lib/pom/init/register-test-user.ts
+++ b/e2e/_lib/pom/init/register-test-user.ts
@@ -1,6 +1,5 @@
-import { RoutePath } from "@/lib/route-path";
 import { generateRandomGUID } from "@/lib/utilities/bark-guid";
-import { Page, expect } from "@playwright/test";
+import { Page } from "@playwright/test";
 import { getTestBirthday } from "../../e2e-test-utils";
 import { initPomContext } from "./init-pom-context";
 import { UserMyPetsPage } from "../pages/user-my-pets-page";

--- a/e2e/_lib/pom/pages/user-registration-page.ts
+++ b/e2e/_lib/pom/pages/user-registration-page.ts
@@ -8,11 +8,15 @@ export class UserRegistrationPage extends PomPage {
   }
 
   dogFormHeader(): Locator {
-    return this.page().locator("form").getByText("Tell us about your pet", {exact: true});
+    return this.page()
+      .locator("form")
+      .getByText("Tell us about your pet", { exact: true });
   }
 
   ownerFormHeader(): Locator {
-    return this.page().locator("form").getByText("Add your details", {exact: true});
+    return this.page()
+      .locator("form")
+      .getByText("Add your details", { exact: true });
   }
 
   dogNameField(): Locator {

--- a/e2e/_lib/pom/pages/user-registration-page.ts
+++ b/e2e/_lib/pom/pages/user-registration-page.ts
@@ -7,6 +7,14 @@ export class UserRegistrationPage extends PomPage {
     return this.website().urlOf(RoutePath.USER_REGISTRATION);
   }
 
+  dogFormHeader(): Locator {
+    return this.page().locator("form").getByText("Tell us about your pet", {exact: true});
+  }
+
+  ownerFormHeader(): Locator {
+    return this.page().locator("form").getByText("Add your details", {exact: true});
+  }
+
   dogNameField(): Locator {
     return this.page().getByLabel("What's your dog's name?");
   }

--- a/e2e/_lib/pom/pages/user-registration-page.ts
+++ b/e2e/_lib/pom/pages/user-registration-page.ts
@@ -1,0 +1,165 @@
+import { RoutePath } from "@/lib/route-path";
+import { PomPage } from "../core/pom-page";
+import { Locator } from "@playwright/test";
+
+export class UserRegistrationPage extends PomPage {
+  url(): string {
+    return this.website().urlOf(RoutePath.USER_REGISTRATION);
+  }
+
+  dogNameField(): Locator {
+    return this.page().getByLabel("What's your dog's name?");
+  }
+
+  dogBreedField(): Locator {
+    return this.page().getByLabel("What's your dog's breed?");
+  }
+
+  dogBirthdayField(): Locator {
+    return this.page().locator('input[name="dogBirthday"]');
+  }
+
+  dogGender_MALE(): Locator {
+    return this.page().getByRole("button", { name: "Male", exact: true });
+  }
+
+  dogGender_FEMALE(): Locator {
+    return this.page().getByRole("button", { name: "Female", exact: true });
+  }
+
+  dogWeightField(): Locator {
+    return this.page().getByLabel("What's your dog's weight? (KG)");
+  }
+
+  private dogBloodTypeOptions(): Locator {
+    return this.page().getByText("Do you know it's blood type?").locator("..");
+  }
+
+  dogBloodType_UNKNOWN(): Locator {
+    return this.dogBloodTypeOptions().getByLabel("I don't know");
+  }
+
+  dogBloodType_POSITIVE(): Locator {
+    return this.dogBloodTypeOptions().getByLabel("D.E.A 1.1 positive");
+  }
+
+  dogBloodType_NEGATIVE(): Locator {
+    return this.dogBloodTypeOptions().getByLabel("D.E.A 1.1 negative");
+  }
+
+  private dogEverReceivedTransfusionOptions(): Locator {
+    return this.page().getByText("Has it received blood").locator("..");
+  }
+
+  dogEverReceivedTransfusion_UNKNOWN(): Locator {
+    return this.dogEverReceivedTransfusionOptions().getByRole("button", {
+      name: "I don't know",
+      exact: true,
+    });
+  }
+
+  dogEverReceivedTransfusion_YES(): Locator {
+    return this.dogEverReceivedTransfusionOptions().getByRole("button", {
+      name: "Yes",
+      exact: true,
+    });
+  }
+
+  dogEverReceivedTransfusion_NO(): Locator {
+    return this.dogEverReceivedTransfusionOptions().getByRole("button", {
+      name: "No",
+      exact: true,
+    });
+  }
+
+  private dogEverPregnantOptions(): Locator {
+    return this.page().getByText("Has your dog been pregnant").locator("..");
+  }
+
+  dogEverPregnant_UNKNOWN(): Locator {
+    return this.dogEverPregnantOptions().getByRole("button", {
+      name: "I don't know",
+      exact: true,
+    });
+  }
+
+  dogEverPregnant_YES(): Locator {
+    return this.dogEverPregnantOptions().getByRole("button", {
+      name: "Yes",
+      exact: true,
+    });
+  }
+
+  dogEverPregnant_NO(): Locator {
+    return this.dogEverPregnantOptions().getByRole("button", {
+      name: "No",
+      exact: true,
+    });
+  }
+
+  dogPreferredVet_VetClinic1(): Locator {
+    return this.page().getByLabel("Vet Clinic 1");
+  }
+
+  nextButton(): Locator {
+    return this.page().getByRole("button", { name: "Next" });
+  }
+
+  cancelButton(): Locator {
+    return this.page().getByRole("button", { name: "Cancel" });
+  }
+
+  userResidency_SINGAPORE(): Locator {
+    return this.page()
+      .getByText("Are you currently based in Singapore")
+      .locator("..")
+      .getByRole("button", { name: "Yes", exact: true });
+  }
+
+  userResidency_OTHER(): Locator {
+    return this.page()
+      .getByText("Are you currently based in Singapore")
+      .locator("..")
+      .getByRole("button", { name: "No", exact: true });
+  }
+
+  userNameField(): Locator {
+    return this.page().getByLabel("How would you like to be");
+  }
+
+  userPhoneNumberField(): Locator {
+    return this.page().getByLabel("What number can we reach you");
+  }
+
+  userEmailField(): Locator {
+    return this.page().getByLabel("Please provide a login email");
+  }
+
+  sendOtpButton(): Locator {
+    return this.page().getByRole("button", { name: "Send me an OTP" });
+  }
+
+  disclaimerCheckbox(): Locator {
+    return this.page().getByLabel("Disclaimer");
+  }
+
+  otpField(): Locator {
+    return this.page().getByLabel("Enter OTP");
+  }
+
+  submitButton(): Locator {
+    return this.page().getByRole("button", { name: "Submit" });
+  }
+
+  backButton(): Locator {
+    return this.page().getByRole("button", { name: "Back" });
+  }
+
+  accountCreatedMessage(): Locator {
+    return this.page().getByText("your account has been created");
+  }
+
+  enterDashboardButton(): Locator {
+    return this.page().getByRole("button", { name: "Enter My Dashboard" });
+  }
+}

--- a/e2e/visitor/visitor-can-register.spec.ts
+++ b/e2e/visitor/visitor-can-register.spec.ts
@@ -9,16 +9,16 @@ import { UserMyAccountPage } from "../_lib/pom/pages/user-my-account-page";
 import { UserMyPetsPage } from "../_lib/pom/pages/user-my-pets-page";
 
 test("visitor can register a new user account", async ({ page }) => {
+  // Navigating to the registration form
   const context = await initPomContext({ page });
-
   const pg1 = new UserLoginPage(context);
   await pg1.checkUrl();
   await pg1.registerLink().click();
 
+  // Fill in the dog form
   const pg2 = new UserRegistrationPage(context);
   await pg2.checkUrl();
-
-  await expect(pg2.dogNameField()).toBeVisible();
+  await expect(pg2.dogFormHeader()).toBeVisible();
   await pg2.dogNameField().fill("Casper");
   await pg2.dogBreedField().fill("White Sheet Dog");
   const dogBirthday = getTestBirthday(6);
@@ -31,33 +31,46 @@ test("visitor can register a new user account", async ({ page }) => {
   await pg2.dogPreferredVet_VetClinic1().click();
   await pg2.nextButton().click();
 
-  await expect(pg2.userResidency_OTHER()).toBeVisible();
+  // Fill in the owner form
+  await expect(pg2.ownerFormHeader()).toBeVisible();
   await pg2.userResidency_SINGAPORE().click();
   await pg2.userNameField().fill("Ian Little");
   await pg2.userPhoneNumberField().fill("87654321");
   const guid = generateRandomGUID(8);
   const userEmail = `ian.${guid}@user.com`;
   await pg2.userEmailField().fill(userEmail);
+
+  // Go back to the dog form and back to the owner form. This checks if the data
+  // entered for dog and owner are preserved.
+  await pg2.backButton().click();
+  await expect(pg2.dogFormHeader()).toBeVisible();
+  await pg2.nextButton().click();
+  await expect(pg2.ownerFormHeader()).toBeVisible();
+
+  // Request OTP and submit
   await pg2.sendOtpButton().click();
   await pg2.otpField().fill("000000");
   await pg2.disclaimerCheckbox().click();
   await pg2.submitButton().click();
 
+  // Registered page. Click enter dashboard button.
   await expect(pg2.accountCreatedMessage()).toBeVisible();
   await expect(pg2.enterDashboardButton()).toBeVisible();
   await pg2.enterDashboardButton().click();
 
+  // Check for expected dog in my pets
   const pg3 = new UserMyPetsPage(context);
   await pg3.checkUrl();
   await expect(pg3.dogCardItem("Casper").locator()).toBeVisible();
 
+  // Navigate to my account page
   const nav = new NavComponent(context);
   await expect(nav.locator()).toBeVisible();
   await nav.myAcountOption().click();
 
+  // Check for account details
   const pg4 = new UserMyAccountPage(context);
   await pg4.checkUrl();
-
   await expect(pg4.exactText("Ian Little")).toBeVisible();
   await expect(pg4.exactText("87654321")).toBeVisible();
   await expect(pg4.exactText(userEmail)).toBeVisible();

--- a/e2e/visitor/visitor-can-register.spec.ts
+++ b/e2e/visitor/visitor-can-register.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+import { initPomContext } from "../_lib/pom/init/init-pom-context";
+import { UserLoginPage } from "../_lib/pom/pages/user-login-page";
+import { UserRegistrationPage } from "../_lib/pom/pages/user-registration-page";
+import { getTestBirthday } from "../_lib/e2e-test-utils";
+import { generateRandomGUID } from "@/lib/utilities/bark-guid";
+import { NavComponent } from "../_lib/pom/layout/nav-component";
+import { UserMyAccountPage } from "../_lib/pom/pages/user-my-account-page";
+import { UserMyPetsPage } from "../_lib/pom/pages/user-my-pets-page";
+
+test("visitor can register a new user account", async ({ page }) => {
+  const context = await initPomContext({ page });
+
+  const pg1 = new UserLoginPage(context);
+  await pg1.checkUrl();
+  await pg1.registerLink().click();
+
+  const pg2 = new UserRegistrationPage(context);
+  await pg2.checkUrl();
+
+  await expect(pg2.dogNameField()).toBeVisible();
+  await pg2.dogNameField().fill("Casper");
+  await pg2.dogBreedField().fill("White Sheet Dog");
+  const dogBirthday = getTestBirthday(6);
+  await pg2.dogBirthdayField().fill(dogBirthday);
+  await pg2.dogWeightField().fill("42");
+  await pg2.dogGender_MALE().click();
+  await pg2.dogBloodType_UNKNOWN().click();
+  await pg2.dogEverPregnant_NO().click();
+  await pg2.dogEverReceivedTransfusion_NO().click();
+  await pg2.dogPreferredVet_VetClinic1().click();
+  await pg2.nextButton().click();
+
+  await expect(pg2.userResidency_OTHER()).toBeVisible();
+  await pg2.userResidency_SINGAPORE().click();
+  await pg2.userNameField().fill("Ian Little");
+  await pg2.userPhoneNumberField().fill("87654321");
+  const guid = generateRandomGUID(8);
+  const userEmail = `ian.${guid}@user.com`;
+  await pg2.userEmailField().fill(userEmail);
+  await pg2.sendOtpButton().click();
+  await pg2.otpField().fill("000000");
+  await pg2.disclaimerCheckbox().click();
+  await pg2.submitButton().click();
+
+  await expect(pg2.accountCreatedMessage()).toBeVisible();
+  await expect(pg2.enterDashboardButton()).toBeVisible();
+  await pg2.enterDashboardButton().click();
+
+  const pg3 = new UserMyPetsPage(context);
+  await pg3.checkUrl();
+  await expect(pg3.dogCardItem("Casper").locator()).toBeVisible();
+
+  const nav = new NavComponent(context);
+  await expect(nav.locator()).toBeVisible();
+  await nav.myAcountOption().click();
+
+  const pg4 = new UserMyAccountPage(context);
+  await pg4.checkUrl();
+
+  await expect(pg4.exactText("Ian Little")).toBeVisible();
+  await expect(pg4.exactText("87654321")).toBeVisible();
+  await expect(pg4.exactText(userEmail)).toBeVisible();
+});


### PR DESCRIPTION
(1) Test the user registration flow.

(2) Details

—(a) A UserRegistrationPage POM was defined.

—(b) A visitor-can-register scenario was written using the UserRegistrationPage POM.

—(c) The register-test-user init function was updated to use the new UserRegistrationPage POM.

(3) Other changes

—(a) Use matrix strategy to run chromium and mobile chrome tests in parallel.
