### PR TITLE
Standardised error codes and server action func names

### DIFF
--- a/src/app/user/(logged-in)/my-account/edit/_action/post-my-account-details.ts
+++ b/src/app/user/(logged-in)/my-account/edit/_action/post-my-account-details.ts
@@ -4,22 +4,22 @@ import { getAuthenticatedUserActor } from "@/lib/auth";
 import { RoutePath } from "@/lib/route-path";
 import { updateMyAccountDetails } from "@/lib/user/actions/update-my-account-details";
 import { MyAccountDetailsUpdate } from "@/lib/user/user-models";
-import { BARK_CODE } from "@/lib/utilities/bark-code";
+import { CODE } from "@/lib/utilities/bark-code";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 export async function postMyAccountDetails(
   request: MyAccountDetailsUpdate,
-): Promise<typeof BARK_CODE.OK | typeof BARK_CODE.FAILED> {
+): Promise<typeof CODE.OK | typeof CODE.FAILED> {
   const actor = await getAuthenticatedUserActor();
   if (actor === null) {
     redirect(RoutePath.USER_LOGIN_PAGE);
   }
 
   const response = await updateMyAccountDetails(actor, request);
-  if (response === BARK_CODE.OK) {
+  if (response === CODE.OK) {
     revalidatePath("/user/(logged-in)/my-account");
-    return BARK_CODE.OK;
+    return CODE.OK;
   }
-  return BARK_CODE.FAILED;
+  return CODE.FAILED;
 }

--- a/src/app/user/(logged-in)/my-account/edit/_action/post-my-account-details.ts
+++ b/src/app/user/(logged-in)/my-account/edit/_action/post-my-account-details.ts
@@ -12,7 +12,7 @@ export type UpdateAccountDetailsResponse =
   | "STATUS_204_UPDATED"
   | "STATUS_500_INTERNAL_SERVER_ERROR";
 
-export async function updateAccountDetails(
+export async function postMyAccountDetails(
   request: MyAccountDetailsUpdate,
 ): Promise<UpdateAccountDetailsResponse> {
   const actor = await getAuthenticatedUserActor();

--- a/src/app/user/(logged-in)/my-account/edit/_action/post-my-account-details.ts
+++ b/src/app/user/(logged-in)/my-account/edit/_action/post-my-account-details.ts
@@ -4,26 +4,22 @@ import { getAuthenticatedUserActor } from "@/lib/auth";
 import { RoutePath } from "@/lib/route-path";
 import { updateMyAccountDetails } from "@/lib/user/actions/update-my-account-details";
 import { MyAccountDetailsUpdate } from "@/lib/user/user-models";
+import { BARK_CODE } from "@/lib/utilities/bark-code";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
-// WIP: Use BARK_CODE
-export type UpdateAccountDetailsResponse =
-  | "STATUS_204_UPDATED"
-  | "STATUS_500_INTERNAL_SERVER_ERROR";
-
 export async function postMyAccountDetails(
   request: MyAccountDetailsUpdate,
-): Promise<UpdateAccountDetailsResponse> {
+): Promise<typeof BARK_CODE.OK | typeof BARK_CODE.FAILED> {
   const actor = await getAuthenticatedUserActor();
   if (actor === null) {
     redirect(RoutePath.USER_LOGIN_PAGE);
   }
 
   const response = await updateMyAccountDetails(actor, request);
-  if (response === "OK") {
+  if (response === BARK_CODE.OK) {
     revalidatePath("/user/(logged-in)/my-account");
-    return "STATUS_204_UPDATED";
+    return BARK_CODE.OK;
   }
-  return "STATUS_500_INTERNAL_SERVER_ERROR";
+  return BARK_CODE.FAILED;
 }

--- a/src/app/user/(logged-in)/my-account/edit/_action/update-my-account-details.ts
+++ b/src/app/user/(logged-in)/my-account/edit/_action/update-my-account-details.ts
@@ -8,6 +8,7 @@ import { MyAccountDetailsUpdate } from "@/lib/user/user-models";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
+// WIP: Use BARK_CODE
 export type UpdateAccountDetailsResponse =
   | "STATUS_204_UPDATED"
   | "STATUS_500_INTERNAL_SERVER_ERROR";

--- a/src/app/user/(logged-in)/my-account/edit/_action/update-my-account-details.ts
+++ b/src/app/user/(logged-in)/my-account/edit/_action/update-my-account-details.ts
@@ -21,7 +21,7 @@ export async function updateAccountDetails(
   }
 
   const response = await updateMyAccountDetails(actor, request);
-  if (response === "OK_UPDATED") {
+  if (response === "OK") {
     revalidatePath("/user/(logged-in)/my-account");
     return "STATUS_204_UPDATED";
   }

--- a/src/app/user/(logged-in)/my-account/edit/_action/update-my-account-details.ts
+++ b/src/app/user/(logged-in)/my-account/edit/_action/update-my-account-details.ts
@@ -2,7 +2,6 @@
 
 import { getAuthenticatedUserActor } from "@/lib/auth";
 import { RoutePath } from "@/lib/route-path";
-import { getMyAccount } from "@/lib/user/actions/get-my-account";
 import { updateMyAccountDetails } from "@/lib/user/actions/update-my-account-details";
 import { MyAccountDetailsUpdate } from "@/lib/user/user-models";
 import { revalidatePath } from "next/cache";
@@ -17,11 +16,7 @@ export async function updateAccountDetails(
   request: MyAccountDetailsUpdate,
 ): Promise<UpdateAccountDetailsResponse> {
   const actor = await getAuthenticatedUserActor();
-  if (!actor) {
-    redirect(RoutePath.USER_LOGIN_PAGE);
-  }
-  const account = await getMyAccount(actor);
-  if (!account) {
+  if (actor === null) {
     redirect(RoutePath.USER_LOGIN_PAGE);
   }
 

--- a/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
+++ b/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
@@ -15,7 +15,7 @@ import { postMyAccountDetails } from "../_action/post-my-account-details";
 import { MyAccountDetailsUpdate } from "@/lib/user/user-models";
 import React from "react";
 import { BarkButton } from "@/components/bark/bark-button";
-import { BARK_CODE } from "@/lib/utilities/bark-code";
+import { CODE } from "@/lib/utilities/bark-code";
 
 const FORM_SCHEMA = z.object({
   userName: z.string().min(1, { message: "Name cannot be empty" }),
@@ -50,7 +50,7 @@ export default function AccountEditForm({
     const request: MyAccountDetailsUpdate = values;
 
     const response = await postMyAccountDetails(request);
-    if (response === BARK_CODE.OK) {
+    if (response === CODE.OK) {
       router.push(RoutePath.USER_MY_ACCOUNT_PAGE);
       return;
     }

--- a/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
+++ b/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
@@ -11,7 +11,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { postMyAccountDetails } from "../_action/put-my-account-details";
+import { postMyAccountDetails } from "../_action/post-my-account-details";
 import { MyAccountDetailsUpdate } from "@/lib/user/user-models";
 import React from "react";
 import { BarkButton } from "@/components/bark/bark-button";

--- a/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
+++ b/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
@@ -11,10 +11,11 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { postMyAccountDetails } from "../_action/post-my-account-details";
+import { postMyAccountDetails } from "../_action/put-my-account-details";
 import { MyAccountDetailsUpdate } from "@/lib/user/user-models";
-import React, { ButtonHTMLAttributes } from "react";
+import React from "react";
 import { BarkButton } from "@/components/bark/bark-button";
+import { BARK_CODE } from "@/lib/utilities/bark-code";
 
 const FORM_SCHEMA = z.object({
   userName: z.string().min(1, { message: "Name cannot be empty" }),
@@ -49,7 +50,7 @@ export default function AccountEditForm({
     const request: MyAccountDetailsUpdate = values;
 
     const response = await postMyAccountDetails(request);
-    if (response === "STATUS_204_UPDATED") {
+    if (response === BARK_CODE.OK) {
       router.push(RoutePath.USER_MY_ACCOUNT_PAGE);
       return;
     }

--- a/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
+++ b/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
@@ -11,7 +11,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { updateAccountDetails } from "../_action/update-my-account-details";
+import { postMyAccountDetails } from "../_action/post-my-account-details";
 import { MyAccountDetailsUpdate } from "@/lib/user/user-models";
 import React, { ButtonHTMLAttributes } from "react";
 import { BarkButton } from "@/components/bark/bark-button";
@@ -48,7 +48,7 @@ export default function AccountEditForm({
     setUpdateError("");
     const request: MyAccountDetailsUpdate = values;
 
-    const response = await updateAccountDetails(request);
+    const response = await postMyAccountDetails(request);
     if (response === "STATUS_204_UPDATED") {
       router.push(RoutePath.USER_MY_ACCOUNT_PAGE);
       return;

--- a/src/app/user/(logged-in)/my-account/edit/page.tsx
+++ b/src/app/user/(logged-in)/my-account/edit/page.tsx
@@ -7,14 +7,10 @@ import { redirect } from "next/navigation";
 
 export default async function Page() {
   const actor = await getAuthenticatedUserActor();
-  if (!actor) {
+  if (actor === null) {
     redirect(RoutePath.USER_LOGIN_PAGE);
   }
   const account = await getMyAccount(actor);
-  if (!account) {
-    redirect(RoutePath.USER_LOGIN_PAGE);
-  }
-
   const { userName, userPhoneNumber, userResidency } = account;
   const props = { userName, userPhoneNumber, userResidency };
 

--- a/src/app/user/(logged-in)/my-account/edit/page.tsx
+++ b/src/app/user/(logged-in)/my-account/edit/page.tsx
@@ -10,7 +10,10 @@ export default async function Page() {
   if (actor === null) {
     redirect(RoutePath.USER_LOGIN_PAGE);
   }
-  const account = await getMyAccount(actor);
+  const { result: account, error } = await getMyAccount(actor);
+  if (error !== undefined) {
+    redirect(RoutePath.USER_LOGIN_PAGE);
+  }
   const { userName, userPhoneNumber, userResidency } = account;
   const props = { userName, userPhoneNumber, userResidency };
 

--- a/src/app/user/(logged-in)/my-account/page.tsx
+++ b/src/app/user/(logged-in)/my-account/page.tsx
@@ -19,22 +19,33 @@ export default async function Page() {
   if (actor === null) {
     redirect(RoutePath.USER_LOGIN_PAGE);
   }
-  const { result: account, error } = await getMyAccount(actor);
-  if (error !== undefined) {
-    redirect(RoutePath.USER_LOGIN_PAGE);
-  }
   const {
     userCreationTime,
     userResidency,
     userName,
     userEmail,
     userPhoneNumber,
-  } = account;
+  } = await getMyAccount(actor).then(({ result, error }) => {
+    if (error !== undefined) {
+      redirect(RoutePath.USER_LOGIN_PAGE);
+    }
+    return result;
+  });
 
-  let latestCall = (await getMyLatestCall(actor))?.userLastContactedTime;
-  const latestCallText = latestCall
-    ? formatDistanceStrict(latestCall, new Date(), { addSuffix: true })
-    : "N.A";
+  const latestCallText = await getMyLatestCall(actor).then(
+    ({ result, error }) => {
+      if (error !== undefined) {
+        return "N.A";
+      }
+      const { userLastContactedTime } = result;
+      if (userLastContactedTime === null) {
+        return "N.A";
+      }
+      return formatDistanceStrict(userLastContactedTime, new Date(), {
+        addSuffix: true,
+      });
+    },
+  );
 
   const userCreationTimeText = formatDateTime(userCreationTime, {
     format: "dd MMM yyyy",

--- a/src/app/user/(logged-in)/my-account/page.tsx
+++ b/src/app/user/(logged-in)/my-account/page.tsx
@@ -19,7 +19,10 @@ export default async function Page() {
   if (actor === null) {
     redirect(RoutePath.USER_LOGIN_PAGE);
   }
-  const account = await getMyAccount(actor);
+  const { result: account, error } = await getMyAccount(actor);
+  if (error !== undefined) {
+    redirect(RoutePath.USER_LOGIN_PAGE);
+  }
   const {
     userCreationTime,
     userResidency,

--- a/src/app/user/(logged-in)/my-account/page.tsx
+++ b/src/app/user/(logged-in)/my-account/page.tsx
@@ -3,7 +3,6 @@
 import { getAuthenticatedUserActor } from "@/lib/auth";
 import { RoutePath } from "@/lib/route-path";
 import { redirect } from "next/navigation";
-import { buttonVariants } from "@/components/ui/button";
 import { IMG_PATH } from "@/lib/image-path";
 import { getMyLatestCall } from "@/lib/user/actions/get-my-latest-call";
 import { getMyAccount } from "@/lib/user/actions/get-my-account";
@@ -13,18 +12,14 @@ import Image from "next/image";
 
 import { capitalize } from "lodash";
 import { formatDateTime, SINGAPORE_TIME_ZONE } from "@/lib/utilities/bark-time";
-import Link from "next/link";
 import { BarkButton } from "@/components/bark/bark-button";
 
 export default async function Page() {
   const actor = await getAuthenticatedUserActor();
-  if (!actor) {
+  if (actor === null) {
     redirect(RoutePath.USER_LOGIN_PAGE);
   }
   const account = await getMyAccount(actor);
-  if (!account) {
-    redirect(RoutePath.USER_LOGIN_PAGE);
-  }
   const {
     userCreationTime,
     userResidency,

--- a/src/app/user/(logged-in)/my-pets/add-dog/_actions/post-dog-profile.ts
+++ b/src/app/user/(logged-in)/my-pets/add-dog/_actions/post-dog-profile.ts
@@ -8,8 +8,7 @@ import { CODE } from "@/lib/utilities/bark-code";
 import { Err, Ok, Result } from "@/lib/utilities/result";
 import { revalidatePath } from "next/cache";
 
-// WIP: rename to postDogProfile
-export async function submitDog(
+export async function postDogProfile(
   dogProfile: DogProfile,
 ): Promise<
   Result<

--- a/src/app/user/(logged-in)/my-pets/add-dog/_actions/submit-dog.ts
+++ b/src/app/user/(logged-in)/my-pets/add-dog/_actions/submit-dog.ts
@@ -7,6 +7,7 @@ import { DogProfile } from "@/lib/user/user-models";
 import { Err, Result } from "@/lib/utilities/result";
 import { revalidatePath } from "next/cache";
 
+// WIP: Use BARK_CODE
 export async function submitDog(
   dogProfile: DogProfile,
 ): Promise<Result<{ dogId: string }, "FAILED" | "ERROR_UNAUTHORIZED">> {

--- a/src/app/user/(logged-in)/my-pets/add-dog/_actions/submit-dog.ts
+++ b/src/app/user/(logged-in)/my-pets/add-dog/_actions/submit-dog.ts
@@ -8,6 +8,7 @@ import { Err, Result } from "@/lib/utilities/result";
 import { revalidatePath } from "next/cache";
 
 // WIP: Use BARK_CODE
+// WIP: rename to postDogProfile
 export async function submitDog(
   dogProfile: DogProfile,
 ): Promise<Result<{ dogId: string }, "FAILED" | "ERROR_UNAUTHORIZED">> {

--- a/src/app/user/(logged-in)/my-pets/add-dog/_components/add-dog-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/add-dog/_components/add-dog-form.tsx
@@ -10,6 +10,7 @@ import { submitDog } from "../_actions/submit-dog";
 import { useRouter } from "next/navigation";
 import { RoutePath } from "@/lib/route-path";
 import { Err, Ok, Result } from "@/lib/utilities/result";
+import { CODE } from "@/lib/utilities/bark-code";
 
 export default function AddDogForm(props: { vetOptions: BarkFormOption[] }) {
   const router = useRouter();
@@ -31,10 +32,11 @@ export default function AddDogForm(props: { vetOptions: BarkFormOption[] }) {
       ...otherFields,
     };
     const { error } = await submitDog(dogProfile);
+    if (error === CODE.ERROR_NOT_LOGGED_IN) {
+      router.push(RoutePath.USER_LOGIN_PAGE);
+      return Err(error);
+    }
     if (error !== undefined) {
-      if (error === "ERROR_UNAUTHORIZED") {
-        router.push(RoutePath.USER_LOGIN_PAGE);
-      }
       return Err(error);
     }
     router.push(RoutePath.USER_MY_PETS);

--- a/src/app/user/(logged-in)/my-pets/add-dog/_components/add-dog-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/add-dog/_components/add-dog-form.tsx
@@ -6,7 +6,7 @@ import GeneralDogForm, {
 } from "../../_components/general-dog-form";
 import { DogProfile } from "@/lib/user/user-models";
 import { UTC_DATE_OPTION, parseDateTime } from "@/lib/utilities/bark-time";
-import { submitDog } from "../_actions/submit-dog";
+import { postDogProfile } from "../_actions/post-dog-profile";
 import { useRouter } from "next/navigation";
 import { RoutePath } from "@/lib/route-path";
 import { Err, Ok, Result } from "@/lib/utilities/result";
@@ -31,7 +31,7 @@ export default function AddDogForm(props: { vetOptions: BarkFormOption[] }) {
       dogWeightKg,
       ...otherFields,
     };
-    const { error } = await submitDog(dogProfile);
+    const { error } = await postDogProfile(dogProfile);
     if (error === CODE.ERROR_NOT_LOGGED_IN) {
       router.push(RoutePath.USER_LOGIN_PAGE);
       return Err(error);

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/post-dog-profile-update.ts
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/post-dog-profile-update.ts
@@ -17,7 +17,7 @@ export async function postDogProfileUpdate(args: {
   | typeof CODE.ERROR_WRONG_OWNER
   | typeof CODE.ERROR_DOG_NOT_FOUND
   | typeof CODE.DB_QUERY_FAILURE
-  | typeof CODE.EXCEPTION
+  | typeof CODE.FAILED
 > {
   const { dogId, dogProfile } = args;
   const actor = await getAuthenticatedUserActor();
@@ -25,9 +25,9 @@ export async function postDogProfileUpdate(args: {
     return CODE.ERROR_NOT_LOGGED_IN;
   }
   const res = await updateDogProfile(actor, dogId, dogProfile);
-  if (res === CODE.OK) {
-    revalidatePath(RoutePath.USER_MY_PETS, "layout");
-    return CODE.OK;
+  if (res !== CODE.OK) {
+    return res;
   }
-  return res;
+  revalidatePath(RoutePath.USER_MY_PETS, "layout");
+  return CODE.OK;
 }

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/post-dog-profile-update.ts
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/post-dog-profile-update.ts
@@ -4,30 +4,30 @@ import { getAuthenticatedUserActor } from "@/lib/auth";
 import { RoutePath } from "@/lib/route-path";
 import { updateDogProfile } from "@/lib/user/actions/update-dog-profile";
 import { DogProfile } from "@/lib/user/user-models";
-import { BARK_CODE } from "@/lib/utilities/bark-code";
+import { CODE } from "@/lib/utilities/bark-code";
 import { revalidatePath } from "next/cache";
 
 export async function postDogProfileUpdate(args: {
   dogId: string;
   dogProfile: DogProfile;
 }): Promise<
-  | typeof BARK_CODE.OK
-  | typeof BARK_CODE.ERROR_NOT_LOGGED_IN
-  | typeof BARK_CODE.ERROR_CANNOT_UPDATE_FULL_PROFILE
-  | typeof BARK_CODE.ERROR_WRONG_OWNER
-  | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
-  | typeof BARK_CODE.DB_QUERY_FAILURE
-  | typeof BARK_CODE.EXCEPTION
+  | typeof CODE.OK
+  | typeof CODE.ERROR_NOT_LOGGED_IN
+  | typeof CODE.ERROR_CANNOT_UPDATE_FULL_PROFILE
+  | typeof CODE.ERROR_WRONG_OWNER
+  | typeof CODE.ERROR_DOG_NOT_FOUND
+  | typeof CODE.DB_QUERY_FAILURE
+  | typeof CODE.EXCEPTION
 > {
   const { dogId, dogProfile } = args;
   const actor = await getAuthenticatedUserActor();
   if (actor === null) {
-    return BARK_CODE.ERROR_NOT_LOGGED_IN;
+    return CODE.ERROR_NOT_LOGGED_IN;
   }
   const res = await updateDogProfile(actor, dogId, dogProfile);
-  if (res === BARK_CODE.OK) {
+  if (res === CODE.OK) {
     revalidatePath(RoutePath.USER_MY_PETS, "layout");
-    return BARK_CODE.OK;
+    return CODE.OK;
   }
   return res;
 }

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/post-dog-profile-update.ts
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/post-dog-profile-update.ts
@@ -7,8 +7,7 @@ import { DogProfile } from "@/lib/user/user-models";
 import { BARK_CODE } from "@/lib/utilities/bark-code";
 import { revalidatePath } from "next/cache";
 
-// WIP: rename to postDogProfileUpdate
-export async function updateDogProfileAction(args: {
+export async function postDogProfileUpdate(args: {
   dogId: string;
   dogProfile: DogProfile;
 }): Promise<

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/update-dog-profile-action.ts
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/update-dog-profile-action.ts
@@ -4,30 +4,31 @@ import { getAuthenticatedUserActor } from "@/lib/auth";
 import { RoutePath } from "@/lib/route-path";
 import { updateDogProfile } from "@/lib/user/actions/update-dog-profile";
 import { DogProfile } from "@/lib/user/user-models";
+import { BARK_CODE } from "@/lib/utilities/bark-code";
 import { revalidatePath } from "next/cache";
-
-// WIP: Use BARK_CODE
-type ResponseCode =
-  | "ERROR_NOT_LOGGED_IN"
-  | "OK_UPDATED"
-  | "ERROR_UNAUTHORIZED"
-  | "ERROR_REPORT_EXISTS"
-  | "ERROR_MISSING_DOG"
-  | "FAILURE_DB_UPDATE";
 
 // WIP: rename to postDogProfileUpdate
 export async function updateDogProfileAction(args: {
   dogId: string;
   dogProfile: DogProfile;
-}): Promise<ResponseCode> {
+}): Promise<
+  | typeof BARK_CODE.OK
+  | typeof BARK_CODE.ERROR_NOT_LOGGED_IN
+  | typeof BARK_CODE.ERROR_CANNOT_UPDATE_FULL_PROFILE
+  | typeof BARK_CODE.ERROR_WRONG_OWNER
+  | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
+  | typeof BARK_CODE.DB_QUERY_FAILURE
+  | typeof BARK_CODE.EXCEPTION
+> {
   const { dogId, dogProfile } = args;
   const actor = await getAuthenticatedUserActor();
   if (actor === null) {
-    return "ERROR_NOT_LOGGED_IN";
+    return BARK_CODE.ERROR_NOT_LOGGED_IN;
   }
   const res = await updateDogProfile(actor, dogId, dogProfile);
-  if (res === "OK_UPDATED") {
+  if (res === BARK_CODE.OK) {
     revalidatePath(RoutePath.USER_MY_PETS, "layout");
+    return BARK_CODE.OK;
   }
   return res;
 }

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/update-dog-profile-action.ts
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/update-dog-profile-action.ts
@@ -6,6 +6,7 @@ import { updateDogProfile } from "@/lib/user/actions/update-dog-profile";
 import { DogProfile } from "@/lib/user/user-models";
 import { revalidatePath } from "next/cache";
 
+// WIP: Use BARK_CODE
 type ResponseCode =
   | "ERROR_NOT_LOGGED_IN"
   | "OK_UPDATED"

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/update-dog-profile-action.ts
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_actions/update-dog-profile-action.ts
@@ -15,6 +15,7 @@ type ResponseCode =
   | "ERROR_MISSING_DOG"
   | "FAILURE_DB_UPDATE";
 
+// WIP: rename to postDogProfileUpdate
 export async function updateDogProfileAction(args: {
   dogId: string;
   dogProfile: DogProfile;

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_components/edit-dog-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_components/edit-dog-profile-form.tsx
@@ -14,6 +14,7 @@ import GeneralDogForm, {
   DogFormData,
 } from "../../../../_components/general-dog-form";
 import { updateDogProfileAction } from "../_actions/update-dog-profile-action";
+import { BARK_CODE } from "@/lib/utilities/bark-code";
 
 export default function EditDogProfileForm(props: {
   vetOptions: BarkFormOption[];
@@ -28,11 +29,11 @@ export default function EditDogProfileForm(props: {
   ): Promise<Result<true, string>> {
     const dogProfile = toDogProfile(values);
     const res = await updateDogProfileAction({ dogId, dogProfile });
-    if (res === "ERROR_NOT_LOGGED_IN") {
+    if (res === BARK_CODE.ERROR_NOT_LOGGED_IN) {
       router.push(RoutePath.USER_LOGIN_PAGE);
       return Err(res);
     }
-    if (res !== "OK_UPDATED") {
+    if (res !== BARK_CODE.OK) {
       return Err(res);
     }
     router.push(RoutePath.USER_MY_PETS);

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_components/edit-dog-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_components/edit-dog-profile-form.tsx
@@ -14,7 +14,7 @@ import GeneralDogForm, {
   DogFormData,
 } from "../../../../_components/general-dog-form";
 import { postDogProfileUpdate } from "../_actions/post-dog-profile-update";
-import { BARK_CODE } from "@/lib/utilities/bark-code";
+import { CODE } from "@/lib/utilities/bark-code";
 
 export default function EditDogProfileForm(props: {
   vetOptions: BarkFormOption[];
@@ -29,11 +29,11 @@ export default function EditDogProfileForm(props: {
   ): Promise<Result<true, string>> {
     const dogProfile = toDogProfile(values);
     const res = await postDogProfileUpdate({ dogId, dogProfile });
-    if (res === BARK_CODE.ERROR_NOT_LOGGED_IN) {
+    if (res === CODE.ERROR_NOT_LOGGED_IN) {
       router.push(RoutePath.USER_LOGIN_PAGE);
       return Err(res);
     }
-    if (res !== BARK_CODE.OK) {
+    if (res !== CODE.OK) {
       return Err(res);
     }
     router.push(RoutePath.USER_MY_PETS);

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_components/edit-dog-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/_components/edit-dog-profile-form.tsx
@@ -13,7 +13,7 @@ import { Err, Ok, Result } from "@/lib/utilities/result";
 import GeneralDogForm, {
   DogFormData,
 } from "../../../../_components/general-dog-form";
-import { updateDogProfileAction } from "../_actions/update-dog-profile-action";
+import { postDogProfileUpdate } from "../_actions/post-dog-profile-update";
 import { BARK_CODE } from "@/lib/utilities/bark-code";
 
 export default function EditDogProfileForm(props: {
@@ -28,7 +28,7 @@ export default function EditDogProfileForm(props: {
     values: DogFormData,
   ): Promise<Result<true, string>> {
     const dogProfile = toDogProfile(values);
-    const res = await updateDogProfileAction({ dogId, dogProfile });
+    const res = await postDogProfileUpdate({ dogId, dogProfile });
     if (res === BARK_CODE.ERROR_NOT_LOGGED_IN) {
       router.push(RoutePath.USER_LOGIN_PAGE);
       return Err(res);

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/page.tsx
@@ -25,7 +25,7 @@ export default async function Page(props: { params: { dogId: string } }) {
     return (
       <div className="m-3">
         <p>
-          Failed to load your dog's profile. Please refresh the page to try
+          Failed to load your dog&apos;s profile. Please refresh the page to try
           again.
         </p>
       </div>

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/page.tsx
@@ -21,7 +21,8 @@ export default async function Page(props: { params: { dogId: string } }) {
     actor,
     dogId,
   );
-  if (error) {
+  if (error !== undefined) {
+    // TODO: show some error on the page?
     redirect(RoutePath.USER_MY_PETS);
   }
 

--- a/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/dogs/[dogId]/edit/page.tsx
@@ -22,8 +22,14 @@ export default async function Page(props: { params: { dogId: string } }) {
     dogId,
   );
   if (error !== undefined) {
-    // TODO: show some error on the page?
-    redirect(RoutePath.USER_MY_PETS);
+    return (
+      <div className="m-3">
+        <p>
+          Failed to load your dog's profile. Please refresh the page to try
+          again.
+        </p>
+      </div>
+    );
   }
 
   const vetOptions = await APP.getDbPool().then(getVetFormOptions);

--- a/src/app/user/(logged-in)/my-pets/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/page.tsx
@@ -250,7 +250,16 @@ export default async function Page() {
   if (!actor) {
     redirect(RoutePath.USER_LOGIN_PAGE);
   }
-  const dogs = await getMyPets(actor);
+  const { result: dogs, error } = await getMyPets(actor);
+  if (error !== undefined) {
+    return (
+      <div className="m-3">
+        <p className="text-base">
+          Failed to load pet data. Please refresh the page to try again.
+        </p>
+      </div>
+    );
+  }
   return (
     <div className="m-3">
       {dogs.map((dog, idx, ary) => (

--- a/src/app/user/registration/_actions/post-registration-request.ts
+++ b/src/app/user/registration/_actions/post-registration-request.ts
@@ -4,7 +4,7 @@ import APP from "@/lib/app";
 import { RegistrationRequest } from "@/lib/services/registration";
 import { CODE } from "@/lib/utilities/bark-code";
 
-export async function registerNewUser(
+export async function postRegistrationRequest(
   request: RegistrationRequest,
 ): Promise<
   | typeof CODE.OK

--- a/src/app/user/registration/_actions/register-new-user.ts
+++ b/src/app/user/registration/_actions/register-new-user.ts
@@ -6,6 +6,7 @@ import {
   RegistrationResponse,
 } from "@/lib/services/registration";
 
+// WIP: rename to postRegistrationRequest
 export async function registerNewUser(
   request: RegistrationRequest,
 ): Promise<RegistrationResponse> {

--- a/src/app/user/registration/_actions/register-new-user.ts
+++ b/src/app/user/registration/_actions/register-new-user.ts
@@ -1,15 +1,17 @@
 "use server";
 
 import APP from "@/lib/app";
-import {
-  RegistrationRequest,
-  RegistrationResponse,
-} from "@/lib/services/registration";
+import { RegistrationRequest } from "@/lib/services/registration";
+import { CODE } from "@/lib/utilities/bark-code";
 
-// WIP: rename to postRegistrationRequest
 export async function registerNewUser(
   request: RegistrationRequest,
-): Promise<RegistrationResponse> {
+): Promise<
+  | typeof CODE.OK
+  | typeof CODE.ERROR_INVALID_OTP
+  | typeof CODE.ERROR_ACCOUNT_ALREADY_EXISTS
+  | typeof CODE.FAILED
+> {
   const service = await APP.getRegistrationService();
   return service.handle(request);
 }

--- a/src/app/user/registration/_components/donor-form.tsx
+++ b/src/app/user/registration/_components/donor-form.tsx
@@ -14,7 +14,7 @@ import Link from "next/link";
 import { RoutePath } from "@/lib/route-path";
 import { useRouter } from "next/navigation";
 import { BarkFormOption } from "@/components/bark/bark-form";
-import { registerNewUser } from "@/app/user/registration/_actions/register-new-user";
+import { postRegistrationRequest } from "@/app/user/registration/_actions/post-registration-request";
 import { RegistrationRequest } from "@/lib/services/registration";
 import {
   DogAntigenPresence,
@@ -114,7 +114,7 @@ export default function DonorForm(props: {
   async function doRegistration(): Promise<void> {
     setRegistrationError("");
     const req = getRegistrationRequest();
-    const res = await registerNewUser(req);
+    const res = await postRegistrationRequest(req);
     if (res === CODE.ERROR_INVALID_OTP) {
       setRegistrationError(
         "The OTP submitted is invalid. Please request for another and try again.",

--- a/src/app/user/registration/_components/donor-form.tsx
+++ b/src/app/user/registration/_components/donor-form.tsx
@@ -27,6 +27,7 @@ import { signIn } from "next-auth/react";
 import { Button } from "@/components/ui/button";
 import { IMG_PATH } from "@/lib/image-path";
 import { AccountType } from "@/lib/auth-models";
+import { CODE } from "@/lib/utilities/bark-code";
 
 const FORM_SCHEMA = z.object({
   dogName: z.string(),
@@ -114,14 +115,14 @@ export default function DonorForm(props: {
     setRegistrationError("");
     const req = getRegistrationRequest();
     const res = await registerNewUser(req);
-    if (res === "STATUS_401_INVALID_OTP") {
+    if (res === CODE.ERROR_INVALID_OTP) {
       setRegistrationError(
         "The OTP submitted is invalid. Please request for another and try again.",
       );
       setCurrentStep(STEPS.OWNER);
       return;
     }
-    if (res === "STATUS_409_USER_EXISTS") {
+    if (res === CODE.ERROR_ACCOUNT_ALREADY_EXISTS) {
       setRegistrationError(
         <p>
           Account already exists. Please{" "}
@@ -134,10 +135,7 @@ export default function DonorForm(props: {
       setCurrentStep(STEPS.OWNER);
       return;
     }
-    if (
-      res === "STATUS_500_INTERNAL_SERVER_ERROR" ||
-      res === "STATUS_503_DB_CONTENTION"
-    ) {
+    if (res !== CODE.OK) {
       setRegistrationError(
         "Oops! Something went wrong at the Pawtal! Please request for another OTP and try again.",
       );

--- a/src/app/user/registration/_components/owner-form.tsx
+++ b/src/app/user/registration/_components/owner-form.tsx
@@ -11,7 +11,7 @@ import {
   BarkFormSingleCheckbox,
   BarkFormSubmitButton,
 } from "@/components/bark/bark-form";
-import { sendLoginOtp } from "@/lib/server-actions/send-login-otp";
+import { postOtpRequest } from "@/lib/server-actions/post-otp-request";
 import { isValidEmail } from "@/lib/utilities/bark-utils";
 import { USER_RESIDENCY } from "@/lib/data/db-enums";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -60,7 +60,8 @@ export default function OwnerForm(props: {
     const { userEmail } = form.getValues();
     form.clearErrors("emailOtp");
     if (isValidEmail(userEmail)) {
-      await sendLoginOtp({ emailAddress: userEmail, accountType: null });
+      // TODO: if the result of postOtpRequest is FAILED, we should ask user to request for another.
+      await postOtpRequest({ emailAddress: userEmail, accountType: null });
       setRecipientEmail(userEmail);
       form.clearErrors("userEmail");
     } else {

--- a/src/components/bark/login/bark-login-form.tsx
+++ b/src/components/bark/login/bark-login-form.tsx
@@ -14,9 +14,10 @@ import {
 import { useState } from "react";
 import { SignInResponse, signIn } from "next-auth/react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { sendLoginOtp } from "@/lib/server-actions/send-login-otp";
+import { postOtpRequest } from "@/lib/server-actions/post-otp-request";
 import { AccountType } from "@/lib/auth-models";
 import { FormMessage } from "@/components/ui/form";
+import { CODE } from "@/lib/utilities/bark-code";
 
 const FORM_SCHEMA = z.object({
   email: z.string().email(),
@@ -67,11 +68,14 @@ export default function BarkLoginForm(props: {
     form.clearErrors("otp");
     const validEmail = validateEmail(email);
     if (validEmail) {
-      const res = await sendLoginOtp({ emailAddress: validEmail, accountType });
-      if (res === "OK") {
+      const res = await postOtpRequest({
+        emailAddress: validEmail,
+        accountType,
+      });
+      if (res === CODE.OK) {
         setRecipientEmail(validEmail);
         setEmailOtpError("");
-      } else if (res === "NO_ACCOUNT") {
+      } else if (res === CODE.ERROR_ACCOUNT_NOT_FOUND) {
         setRecipientEmail("");
         setEmailOtpError(noAccountErrorMessage);
       } else {

--- a/src/lib/data/db-utils.ts
+++ b/src/lib/data/db-utils.ts
@@ -70,7 +70,7 @@ export async function dbResultQuery<T extends QueryResultRow = any>(
     const result = await dbQuery<T>(ctx, sql, params);
     return Ok(result);
   } catch {
-    return Err(BARK_CODE.FAILURE_DB_QUERY)
+    return Err(BARK_CODE.FAILURE_DB_QUERY);
   }
 }
 

--- a/src/lib/data/db-utils.ts
+++ b/src/lib/data/db-utils.ts
@@ -1,7 +1,7 @@
 import { Pool, PoolClient, QueryResult, QueryResultRow } from "pg";
 import { SlowQueryService } from "./db-slow-query";
 import { Err, Ok, Result } from "../utilities/result";
-import { BARK_CODE } from "../utilities/bark-code";
+import { CODE } from "../utilities/bark-code";
 
 export type DbContext = Pool | PoolClient;
 
@@ -65,12 +65,12 @@ export async function dbResultQuery<T extends QueryResultRow = any>(
   ctx: DbContext,
   sql: string,
   params: any[],
-): Promise<Result<QueryResult<T>, typeof BARK_CODE.DB_QUERY_FAILURE>> {
+): Promise<Result<QueryResult<T>, typeof CODE.DB_QUERY_FAILURE>> {
   try {
     const result = await dbQuery<T>(ctx, sql, params);
     return Ok(result);
   } catch {
-    return Err(BARK_CODE.DB_QUERY_FAILURE);
+    return Err(CODE.DB_QUERY_FAILURE);
   }
 }
 

--- a/src/lib/data/db-utils.ts
+++ b/src/lib/data/db-utils.ts
@@ -1,5 +1,7 @@
 import { Pool, PoolClient, QueryResult, QueryResultRow } from "pg";
 import { SlowQueryService } from "./db-slow-query";
+import { Err, Ok, Result } from "../utilities/result";
+import { BARK_CODE } from "../utilities/bark-code";
 
 export type DbContext = Pool | PoolClient;
 
@@ -56,6 +58,19 @@ export async function dbQuery<T extends QueryResultRow = any>(
   } catch (error) {
     console.error(`SQL: ${sql}`, error);
     throw error;
+  }
+}
+
+export async function dbResultQuery<T extends QueryResultRow = any>(
+  ctx: DbContext,
+  sql: string,
+  params: any[],
+): Promise<Result<QueryResult<T>, typeof BARK_CODE.FAILURE_DB_QUERY>> {
+  try {
+    const result = await dbQuery<T>(ctx, sql, params);
+    return Ok(result);
+  } catch {
+    return Err(BARK_CODE.FAILURE_DB_QUERY)
   }
 }
 

--- a/src/lib/data/db-utils.ts
+++ b/src/lib/data/db-utils.ts
@@ -65,12 +65,12 @@ export async function dbResultQuery<T extends QueryResultRow = any>(
   ctx: DbContext,
   sql: string,
   params: any[],
-): Promise<Result<QueryResult<T>, typeof BARK_CODE.FAILURE_DB_QUERY>> {
+): Promise<Result<QueryResult<T>, typeof BARK_CODE.DB_QUERY_FAILURE>> {
   try {
     const result = await dbQuery<T>(ctx, sql, params);
     return Ok(result);
   } catch {
-    return Err(BARK_CODE.FAILURE_DB_QUERY);
+    return Err(BARK_CODE.DB_QUERY_FAILURE);
   }
 }
 

--- a/src/lib/server-actions/action-errors.ts
+++ b/src/lib/server-actions/action-errors.ts
@@ -1,3 +1,4 @@
+// WIP: Remove these
 export const ERR_401_NO_ACTOR = "ERR_401_NO_ACTOR";
 export const ERR_403_NO_PERMISSION = "ERR_403_NO_PERMISSION";
 export const ERR_500_SERVER_ERROR = "ERR_500_SERVER_ERROR";

--- a/src/lib/server-actions/action-errors.ts
+++ b/src/lib/server-actions/action-errors.ts
@@ -1,4 +1,0 @@
-// WIP: Remove these
-export const ERR_401_NO_ACTOR = "ERR_401_NO_ACTOR";
-export const ERR_403_NO_PERMISSION = "ERR_403_NO_PERMISSION";
-export const ERR_500_SERVER_ERROR = "ERR_500_SERVER_ERROR";

--- a/src/lib/server-actions/post-otp-request.ts
+++ b/src/lib/server-actions/post-otp-request.ts
@@ -2,14 +2,14 @@
 
 import APP from "@/lib/app";
 import { AccountType } from "../auth-models";
+import { CODE } from "../utilities/bark-code";
 
-// WIP: Use BARK_CODE
-type ResponseCode = "OK" | "NO_ACCOUNT" | "SEND_FAILED";
-
-export async function sendLoginOtp(args: {
+export async function postOtpRequest(args: {
   emailAddress: string;
   accountType: AccountType | null;
-}): Promise<ResponseCode> {
+}): Promise<
+  typeof CODE.OK | typeof CODE.ERROR_ACCOUNT_NOT_FOUND | typeof CODE.FAILED
+> {
   const emailOtpService = await APP.getEmailOtpService();
   return emailOtpService.sendOtp(args);
 }

--- a/src/lib/server-actions/send-login-otp.ts
+++ b/src/lib/server-actions/send-login-otp.ts
@@ -3,6 +3,7 @@
 import APP from "@/lib/app";
 import { AccountType } from "../auth-models";
 
+// WIP: Use BARK_CODE
 type ResponseCode = "OK" | "NO_ACCOUNT" | "SEND_FAILED";
 
 export async function sendLoginOtp(args: {

--- a/src/lib/services/email-otp-service.ts
+++ b/src/lib/services/email-otp-service.ts
@@ -19,6 +19,7 @@ type Request = {
   accountType: AccountType | null;
 };
 
+// WIP: use BARK_CODE
 type ResponseCode = "OK" | "NO_ACCOUNT" | "SEND_FAILED";
 
 export class EmailOtpService {

--- a/src/lib/services/email-otp-service.ts
+++ b/src/lib/services/email-otp-service.ts
@@ -4,6 +4,7 @@ import { AccountType } from "../auth-models";
 import { UserActorFactory } from "../user/user-actor-factory";
 import { VetActorFactory } from "../vet/vet-actor-factory";
 import { AdminActorFactory } from "../admin/admin-actor-factory";
+import { CODE } from "../utilities/bark-code";
 
 export type EmailOtpServiceConfig = {
   emailService: EmailService;
@@ -19,9 +20,6 @@ type Request = {
   accountType: AccountType | null;
 };
 
-// WIP: use BARK_CODE
-type ResponseCode = "OK" | "NO_ACCOUNT" | "SEND_FAILED";
-
 export class EmailOtpService {
   private config: EmailOtpServiceConfig;
 
@@ -29,9 +27,13 @@ export class EmailOtpService {
     this.config = config;
   }
 
-  public async sendOtp(request: Request): Promise<ResponseCode> {
+  public async sendOtp(
+    request: Request,
+  ): Promise<
+    typeof CODE.OK | typeof CODE.ERROR_ACCOUNT_NOT_FOUND | typeof CODE.FAILED
+  > {
     const accountCheck = await this.checkAccountExists(request);
-    if (accountCheck !== "OK") {
+    if (accountCheck !== CODE.OK) {
       return accountCheck;
     }
     const { otpService, sender, emailService } = this.config;
@@ -46,14 +48,14 @@ export class EmailOtpService {
     };
     const { error } = await emailService.sendEmail(email);
     if (error !== undefined) {
-      return "SEND_FAILED";
+      return CODE.FAILED;
     }
-    return "OK";
+    return CODE.OK;
   }
 
   private async checkAccountExists(
     request: Request,
-  ): Promise<"OK" | "NO_ACCOUNT"> {
+  ): Promise<typeof CODE.OK | typeof CODE.ERROR_ACCOUNT_NOT_FOUND> {
     const { accountType } = request;
     if (accountType === AccountType.USER) {
       return this.checkUserAccountExists(request);
@@ -65,35 +67,35 @@ export class EmailOtpService {
       return this.checkAdminAccountExists(request);
     }
     if (accountType === null) {
-      return "OK";
+      return CODE.OK;
     }
-    return "NO_ACCOUNT";
+    return CODE.ERROR_ACCOUNT_NOT_FOUND;
   }
 
   private async checkUserAccountExists(
     request: Request,
-  ): Promise<"OK" | "NO_ACCOUNT"> {
+  ): Promise<typeof CODE.OK | typeof CODE.ERROR_ACCOUNT_NOT_FOUND> {
     const { userActorFactory } = this.config;
     const { emailAddress } = request;
     const actor = await userActorFactory.getUserActor(emailAddress);
-    return actor === null ? "NO_ACCOUNT" : "OK";
+    return actor === null ? CODE.ERROR_ACCOUNT_NOT_FOUND : CODE.OK;
   }
 
   private async checkVetAccountExists(
     request: Request,
-  ): Promise<"OK" | "NO_ACCOUNT"> {
+  ): Promise<typeof CODE.OK | typeof CODE.ERROR_ACCOUNT_NOT_FOUND> {
     const { vetActorFactory } = this.config;
     const { emailAddress } = request;
     const actor = await vetActorFactory.getVetActor(emailAddress);
-    return actor === null ? "NO_ACCOUNT" : "OK";
+    return actor === null ? CODE.ERROR_ACCOUNT_NOT_FOUND : CODE.OK;
   }
 
   private async checkAdminAccountExists(
     request: Request,
-  ): Promise<"OK" | "NO_ACCOUNT"> {
+  ): Promise<typeof CODE.OK | typeof CODE.ERROR_ACCOUNT_NOT_FOUND> {
     const { adminActorFactory } = this.config;
     const { emailAddress } = request;
     const actor = await adminActorFactory.getAdminActor(emailAddress);
-    return actor === null ? "NO_ACCOUNT" : "OK";
+    return actor === null ? CODE.ERROR_ACCOUNT_NOT_FOUND : CODE.OK;
   }
 }

--- a/src/lib/services/registration.ts
+++ b/src/lib/services/registration.ts
@@ -17,6 +17,7 @@ import { DogMapper } from "@/lib/data/dog-mapper";
 import { UserMapper } from "@/lib/data/user-mapper";
 import { HashService } from "@/lib/services/hash";
 import { OtpService } from "@/lib/services/otp";
+import { CODE } from "../utilities/bark-code";
 
 export type RegistrationServiceConfig = {
   dbPool: Pool;
@@ -43,14 +44,6 @@ export type RegistrationRequest = {
   dogPreferredVetId?: string;
 };
 
-// WIP: Use BARK_CODE
-export type RegistrationResponse =
-  | "STATUS_201_CREATED"
-  | "STATUS_401_INVALID_OTP"
-  | "STATUS_409_USER_EXISTS"
-  | "STATUS_500_INTERNAL_SERVER_ERROR"
-  | "STATUS_503_DB_CONTENTION";
-
 export class RegistrationService {
   private config: RegistrationServiceConfig;
   constructor(config: RegistrationServiceConfig) {
@@ -59,10 +52,15 @@ export class RegistrationService {
 
   public async handle(
     request: RegistrationRequest,
-  ): Promise<RegistrationResponse> {
+  ): Promise<
+    | typeof CODE.OK
+    | typeof CODE.ERROR_INVALID_OTP
+    | typeof CODE.ERROR_ACCOUNT_ALREADY_EXISTS
+    | typeof CODE.FAILED
+  > {
     const isValidOtp = await this.isValidOtp(request);
     if (!isValidOtp) {
-      return "STATUS_401_INVALID_OTP";
+      return CODE.ERROR_INVALID_OTP;
     }
 
     const conn = await this.config.dbPool.connect();
@@ -74,7 +72,7 @@ export class RegistrationService {
       );
       if (hasExistingUser) {
         await dbRollback(conn);
-        return "STATUS_409_USER_EXISTS";
+        return CODE.ERROR_ACCOUNT_ALREADY_EXISTS;
       }
       const dogGen = await this.registerDog(conn, request, userGen.userId);
       const allInserted = await this.registerVetPreference(
@@ -84,13 +82,13 @@ export class RegistrationService {
       );
       if (!allInserted) {
         await dbRollback(conn);
-        return "STATUS_503_DB_CONTENTION";
+        return CODE.FAILED;
       }
       await dbCommit(conn);
-      return "STATUS_201_CREATED";
+      return CODE.OK;
     } catch (error: unknown) {
       await dbRollback(conn);
-      return "STATUS_500_INTERNAL_SERVER_ERROR";
+      return CODE.FAILED;
     } finally {
       await dbRelease(conn);
     }

--- a/src/lib/services/registration.ts
+++ b/src/lib/services/registration.ts
@@ -43,6 +43,7 @@ export type RegistrationRequest = {
   dogPreferredVetId?: string;
 };
 
+// WIP: Use BARK_CODE
 export type RegistrationResponse =
   | "STATUS_201_CREATED"
   | "STATUS_401_INVALID_OTP"

--- a/src/lib/user/actions/add-my-dog.ts
+++ b/src/lib/user/actions/add-my-dog.ts
@@ -4,12 +4,13 @@ import { DogProfile } from "../user-models";
 import { dbBegin, dbCommit, dbRelease, dbRollback } from "@/lib/data/db-utils";
 import { DogSpec } from "@/lib/data/db-models";
 import { dbInsertDog, dbInsertDogVetPreference } from "@/lib/data/db-dogs";
+import { BARK_CODE } from "@/lib/utilities/bark-code";
 
 type AddDogResult = {
   dogId: string;
 };
 
-type AddDogError = "FAILED";
+type AddDogError = typeof BARK_CODE.FAILED;
 
 export async function addMyDog(
   actor: UserActor,

--- a/src/lib/user/actions/add-my-dog.ts
+++ b/src/lib/user/actions/add-my-dog.ts
@@ -32,7 +32,7 @@ export async function addMyDog(
     await dbCommit(conn);
     return Ok({ dogId });
   } catch {
-    return Err("FAILED");
+    return Err(BARK_CODE.FAILED);
   } finally {
     await dbRollback(conn);
     await dbRelease(conn);

--- a/src/lib/user/actions/add-my-dog.ts
+++ b/src/lib/user/actions/add-my-dog.ts
@@ -4,7 +4,7 @@ import { DogProfile } from "../user-models";
 import { dbBegin, dbCommit, dbRelease, dbRollback } from "@/lib/data/db-utils";
 import { DogSpec } from "@/lib/data/db-models";
 import { dbInsertDog, dbInsertDogVetPreference } from "@/lib/data/db-dogs";
-import { BARK_CODE } from "@/lib/utilities/bark-code";
+import { CODE } from "@/lib/utilities/bark-code";
 
 export async function addMyDog(
   actor: UserActor,
@@ -14,7 +14,7 @@ export async function addMyDog(
     {
       dogId: string;
     },
-    typeof BARK_CODE.EXCEPTION
+    typeof CODE.EXCEPTION
   >
 > {
   const { userId, dbPool, dogMapper } = actor.getParams();
@@ -33,7 +33,7 @@ export async function addMyDog(
     await dbCommit(conn);
     return Ok({ dogId });
   } catch {
-    return Err(BARK_CODE.EXCEPTION);
+    return Err(CODE.EXCEPTION);
   } finally {
     await dbRollback(conn);
     await dbRelease(conn);

--- a/src/lib/user/actions/add-my-dog.ts
+++ b/src/lib/user/actions/add-my-dog.ts
@@ -14,7 +14,7 @@ export async function addMyDog(
     {
       dogId: string;
     },
-    typeof BARK_CODE.FAILED
+    typeof BARK_CODE.EXCEPTION
   >
 > {
   const { userId, dbPool, dogMapper } = actor.getParams();
@@ -33,7 +33,7 @@ export async function addMyDog(
     await dbCommit(conn);
     return Ok({ dogId });
   } catch {
-    return Err(BARK_CODE.FAILED);
+    return Err(BARK_CODE.EXCEPTION);
   } finally {
     await dbRollback(conn);
     await dbRelease(conn);

--- a/src/lib/user/actions/add-my-dog.ts
+++ b/src/lib/user/actions/add-my-dog.ts
@@ -14,7 +14,7 @@ export async function addMyDog(
     {
       dogId: string;
     },
-    typeof CODE.EXCEPTION
+    typeof CODE.FAILED
   >
 > {
   const { userId, dbPool, dogMapper } = actor.getParams();
@@ -33,7 +33,7 @@ export async function addMyDog(
     await dbCommit(conn);
     return Ok({ dogId });
   } catch {
-    return Err(CODE.EXCEPTION);
+    return Err(CODE.FAILED);
   } finally {
     await dbRollback(conn);
     await dbRelease(conn);

--- a/src/lib/user/actions/add-my-dog.ts
+++ b/src/lib/user/actions/add-my-dog.ts
@@ -6,16 +6,17 @@ import { DogSpec } from "@/lib/data/db-models";
 import { dbInsertDog, dbInsertDogVetPreference } from "@/lib/data/db-dogs";
 import { BARK_CODE } from "@/lib/utilities/bark-code";
 
-type AddDogResult = {
-  dogId: string;
-};
-
-type AddDogError = typeof BARK_CODE.FAILED;
-
 export async function addMyDog(
   actor: UserActor,
   dogProfile: DogProfile,
-): Promise<Result<AddDogResult, AddDogError>> {
+): Promise<
+  Result<
+    {
+      dogId: string;
+    },
+    typeof BARK_CODE.FAILED
+  >
+> {
   const { userId, dbPool, dogMapper } = actor.getParams();
   const { dogName, dogPreferredVetId, ...otherFields } = dogProfile;
   const { dogEncryptedOii } = await dogMapper.mapDogOiiToDogSecureOii({

--- a/src/lib/user/actions/get-dog-profile.ts
+++ b/src/lib/user/actions/get-dog-profile.ts
@@ -7,8 +7,11 @@ import {
   DogGender,
   YesNoUnknown,
 } from "@/lib/data/db-enums";
+import { BARK_CODE } from "@/lib/utilities/bark-code";
 
-type ErrorCode = "ERROR_UNAUTHORIZED" | "ERROR_MISSING_DOG";
+type ErrorCode =
+  | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
+  | typeof BARK_CODE.ERROR_WRONG_OWNER;
 
 export async function getDogProfile(
   actor: UserActor,
@@ -54,11 +57,11 @@ export async function getDogProfile(
   };
   const res = await dbQuery<Row>(dbPool, sql, [dogId]);
   if (res.rows.length === 0) {
-    return Err("ERROR_MISSING_DOG");
+    return Err(BARK_CODE.ERROR_DOG_NOT_FOUND);
   }
   const { dogOwnerId, dogEncryptedOii, ...otherFields } = res.rows[0];
   if (dogOwnerId !== userId) {
-    return Err("ERROR_UNAUTHORIZED");
+    return Err(BARK_CODE.ERROR_WRONG_OWNER);
   }
   const { dogName } = await dogMapper.mapDogSecureOiiToDogOii({
     dogEncryptedOii,

--- a/src/lib/user/actions/get-dog-profile.ts
+++ b/src/lib/user/actions/get-dog-profile.ts
@@ -1,4 +1,4 @@
-import { dbQuery, dbResultQuery } from "@/lib/data/db-utils";
+import { dbResultQuery } from "@/lib/data/db-utils";
 import { UserActor } from "../user-actor";
 import { DogProfile } from "../user-models";
 import { Err, Ok, Result } from "@/lib/utilities/result";
@@ -15,7 +15,9 @@ export async function getDogProfile(
 ): Promise<
   Result<
     DogProfile,
-    typeof BARK_CODE.ERROR_DOG_NOT_FOUND | typeof BARK_CODE.ERROR_WRONG_OWNER | typeof BARK_CODE.FAILURE_DB_QUERY
+    | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
+    | typeof BARK_CODE.ERROR_WRONG_OWNER
+    | typeof BARK_CODE.FAILURE_DB_QUERY
   >
 > {
   const { dbPool, userId, dogMapper } = actor.getParams();
@@ -56,7 +58,7 @@ export async function getDogProfile(
     dogEverReceivedTransfusion: YesNoUnknown;
     dogPreferredVetId: string;
   };
-  const {result: res, error} = await dbResultQuery<Row>(dbPool, sql, [dogId]);
+  const { result: res, error } = await dbResultQuery<Row>(dbPool, sql, [dogId]);
   if (error !== undefined) {
     return Err(error);
   }

--- a/src/lib/user/actions/get-dog-profile.ts
+++ b/src/lib/user/actions/get-dog-profile.ts
@@ -9,14 +9,15 @@ import {
 } from "@/lib/data/db-enums";
 import { BARK_CODE } from "@/lib/utilities/bark-code";
 
-type ErrorCode =
-  | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
-  | typeof BARK_CODE.ERROR_WRONG_OWNER;
-
 export async function getDogProfile(
   actor: UserActor,
   dogId: string,
-): Promise<Result<DogProfile, ErrorCode>> {
+): Promise<
+  Result<
+    DogProfile,
+    typeof BARK_CODE.ERROR_DOG_NOT_FOUND | typeof BARK_CODE.ERROR_WRONG_OWNER
+  >
+> {
   const { dbPool, userId, dogMapper } = actor.getParams();
   const sql = `
   SELECT

--- a/src/lib/user/actions/get-dog-profile.ts
+++ b/src/lib/user/actions/get-dog-profile.ts
@@ -17,7 +17,7 @@ export async function getDogProfile(
     DogProfile,
     | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
     | typeof BARK_CODE.ERROR_WRONG_OWNER
-    | typeof BARK_CODE.FAILURE_DB_QUERY
+    | typeof BARK_CODE.DB_QUERY_FAILURE
   >
 > {
   const { dbPool, userId, dogMapper } = actor.getParams();

--- a/src/lib/user/actions/get-dog-profile.ts
+++ b/src/lib/user/actions/get-dog-profile.ts
@@ -7,7 +7,7 @@ import {
   DogGender,
   YesNoUnknown,
 } from "@/lib/data/db-enums";
-import { BARK_CODE } from "@/lib/utilities/bark-code";
+import { CODE } from "@/lib/utilities/bark-code";
 
 export async function getDogProfile(
   actor: UserActor,
@@ -15,9 +15,9 @@ export async function getDogProfile(
 ): Promise<
   Result<
     DogProfile,
-    | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
-    | typeof BARK_CODE.ERROR_WRONG_OWNER
-    | typeof BARK_CODE.DB_QUERY_FAILURE
+    | typeof CODE.ERROR_DOG_NOT_FOUND
+    | typeof CODE.ERROR_WRONG_OWNER
+    | typeof CODE.DB_QUERY_FAILURE
   >
 > {
   const { dbPool, userId, dogMapper } = actor.getParams();
@@ -63,11 +63,11 @@ export async function getDogProfile(
     return Err(error);
   }
   if (res.rows.length === 0) {
-    return Err(BARK_CODE.ERROR_DOG_NOT_FOUND);
+    return Err(CODE.ERROR_DOG_NOT_FOUND);
   }
   const { dogOwnerId, dogEncryptedOii, ...otherFields } = res.rows[0];
   if (dogOwnerId !== userId) {
-    return Err(BARK_CODE.ERROR_WRONG_OWNER);
+    return Err(CODE.ERROR_WRONG_OWNER);
   }
   const { dogName } = await dogMapper.mapDogSecureOiiToDogOii({
     dogEncryptedOii,

--- a/src/lib/user/actions/get-dog-profile.ts
+++ b/src/lib/user/actions/get-dog-profile.ts
@@ -1,4 +1,4 @@
-import { dbQuery } from "@/lib/data/db-utils";
+import { dbQuery, dbResultQuery } from "@/lib/data/db-utils";
 import { UserActor } from "../user-actor";
 import { DogProfile } from "../user-models";
 import { Err, Ok, Result } from "@/lib/utilities/result";
@@ -15,7 +15,7 @@ export async function getDogProfile(
 ): Promise<
   Result<
     DogProfile,
-    typeof BARK_CODE.ERROR_DOG_NOT_FOUND | typeof BARK_CODE.ERROR_WRONG_OWNER
+    typeof BARK_CODE.ERROR_DOG_NOT_FOUND | typeof BARK_CODE.ERROR_WRONG_OWNER | typeof BARK_CODE.FAILURE_DB_QUERY
   >
 > {
   const { dbPool, userId, dogMapper } = actor.getParams();
@@ -56,7 +56,10 @@ export async function getDogProfile(
     dogEverReceivedTransfusion: YesNoUnknown;
     dogPreferredVetId: string;
   };
-  const res = await dbQuery<Row>(dbPool, sql, [dogId]);
+  const {result: res, error} = await dbResultQuery<Row>(dbPool, sql, [dogId]);
+  if (error !== undefined) {
+    return Err(error);
+  }
   if (res.rows.length === 0) {
     return Err(BARK_CODE.ERROR_DOG_NOT_FOUND);
   }

--- a/src/lib/user/actions/get-dog-statuses.ts
+++ b/src/lib/user/actions/get-dog-statuses.ts
@@ -10,14 +10,15 @@ import {
 import { dbQuery } from "@/lib/data/db-utils";
 import { BARK_CODE } from "@/lib/utilities/bark-code";
 
-type ErrorCode =
-  | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
-  | typeof BARK_CODE.ERROR_WRONG_OWNER;
-
 export async function getDogStatuses(
   actor: UserActor,
   dogId: string,
-): Promise<Result<DogStatuses, ErrorCode>> {
+): Promise<
+  Result<
+    DogStatuses,
+    typeof BARK_CODE.ERROR_DOG_NOT_FOUND | typeof BARK_CODE.ERROR_WRONG_OWNER
+  >
+> {
   const { userId } = actor.getParams();
   const ctx: Context = { actor, dogId };
   const row: Row | null = await fetchRow(ctx);

--- a/src/lib/user/actions/get-dog-statuses.ts
+++ b/src/lib/user/actions/get-dog-statuses.ts
@@ -51,10 +51,7 @@ type Row = {
 async function fetchRow(
   ctx: Context,
 ): Promise<
-  Result<
-    Row,
-    typeof CODE.ERROR_DOG_NOT_FOUND | typeof CODE.DB_QUERY_FAILURE
-  >
+  Result<Row, typeof CODE.ERROR_DOG_NOT_FOUND | typeof CODE.DB_QUERY_FAILURE>
 > {
   const { actor, dogId } = ctx;
   const { dbPool } = actor.getParams();

--- a/src/lib/user/actions/get-dog-statuses.ts
+++ b/src/lib/user/actions/get-dog-statuses.ts
@@ -8,7 +8,7 @@ import {
   ServiceStatus,
 } from "@/lib/data/db-enums";
 import { dbResultQuery } from "@/lib/data/db-utils";
-import { BARK_CODE } from "@/lib/utilities/bark-code";
+import { CODE } from "@/lib/utilities/bark-code";
 
 export async function getDogStatuses(
   actor: UserActor,
@@ -16,9 +16,9 @@ export async function getDogStatuses(
 ): Promise<
   Result<
     DogStatuses,
-    | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
-    | typeof BARK_CODE.ERROR_WRONG_OWNER
-    | typeof BARK_CODE.DB_QUERY_FAILURE
+    | typeof CODE.ERROR_DOG_NOT_FOUND
+    | typeof CODE.ERROR_WRONG_OWNER
+    | typeof CODE.DB_QUERY_FAILURE
   >
 > {
   const { userId } = actor.getParams();
@@ -29,7 +29,7 @@ export async function getDogStatuses(
   }
   const { ownerUserId, ...otherFields } = result;
   if (ownerUserId !== userId) {
-    return Err(BARK_CODE.ERROR_WRONG_OWNER);
+    return Err(CODE.ERROR_WRONG_OWNER);
   }
   return Ok(otherFields);
 }
@@ -53,7 +53,7 @@ async function fetchRow(
 ): Promise<
   Result<
     Row,
-    typeof BARK_CODE.ERROR_DOG_NOT_FOUND | typeof BARK_CODE.DB_QUERY_FAILURE
+    typeof CODE.ERROR_DOG_NOT_FOUND | typeof CODE.DB_QUERY_FAILURE
   >
 > {
   const { actor, dogId } = ctx;
@@ -85,7 +85,7 @@ async function fetchRow(
     return Err(error);
   }
   if (res.rows.length == 0) {
-    return Err(BARK_CODE.ERROR_DOG_NOT_FOUND);
+    return Err(CODE.ERROR_DOG_NOT_FOUND);
   }
   return Ok(res.rows[0]);
 }

--- a/src/lib/user/actions/get-dog-statuses.ts
+++ b/src/lib/user/actions/get-dog-statuses.ts
@@ -18,7 +18,7 @@ export async function getDogStatuses(
     DogStatuses,
     | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
     | typeof BARK_CODE.ERROR_WRONG_OWNER
-    | typeof BARK_CODE.FAILURE_DB_QUERY
+    | typeof BARK_CODE.DB_QUERY_FAILURE
   >
 > {
   const { userId } = actor.getParams();
@@ -53,7 +53,7 @@ async function fetchRow(
 ): Promise<
   Result<
     Row,
-    typeof BARK_CODE.ERROR_DOG_NOT_FOUND | typeof BARK_CODE.FAILURE_DB_QUERY
+    typeof BARK_CODE.ERROR_DOG_NOT_FOUND | typeof BARK_CODE.DB_QUERY_FAILURE
   >
 > {
   const { actor, dogId } = ctx;

--- a/src/lib/user/actions/get-dog-statuses.ts
+++ b/src/lib/user/actions/get-dog-statuses.ts
@@ -8,8 +8,11 @@ import {
   ServiceStatus,
 } from "@/lib/data/db-enums";
 import { dbQuery } from "@/lib/data/db-utils";
+import { BARK_CODE } from "@/lib/utilities/bark-code";
 
-type ErrorCode = "ERROR_UNAUTHORIZED" | "ERROR_MISSING_DOG";
+type ErrorCode =
+  | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
+  | typeof BARK_CODE.ERROR_WRONG_OWNER;
 
 export async function getDogStatuses(
   actor: UserActor,
@@ -19,11 +22,11 @@ export async function getDogStatuses(
   const ctx: Context = { actor, dogId };
   const row: Row | null = await fetchRow(ctx);
   if (row === null) {
-    return Err("ERROR_MISSING_DOG");
+    return Err(BARK_CODE.ERROR_DOG_NOT_FOUND);
   }
   const { ownerUserId, ...otherFields } = row;
   if (ownerUserId !== userId) {
-    return Err("ERROR_UNAUTHORIZED");
+    return Err(BARK_CODE.ERROR_WRONG_OWNER);
   }
   return Ok(otherFields);
 }

--- a/src/lib/user/actions/get-my-account.ts
+++ b/src/lib/user/actions/get-my-account.ts
@@ -3,10 +3,7 @@ import { dbQuery } from "@/lib/data/db-utils";
 import { MyAccount } from "../user-models";
 import { UserResidency } from "@/lib/data/db-enums";
 
-// WIP: Change return type to Promise<MyAccount> There's no reason why zero rows should be returned.
-export async function getMyAccount(
-  actor: UserActor,
-): Promise<MyAccount | null> {
+export async function getMyAccount(actor: UserActor): Promise<MyAccount> {
   const { userId, dbPool, userMapper } = actor.getParams();
 
   const sql = `
@@ -27,9 +24,6 @@ export async function getMyAccount(
     userResidency: UserResidency;
   };
   const res = await dbQuery<Row>(dbPool, sql, [userId]);
-  if (res.rows.length === 0) {
-    return null;
-  }
   const { userHashedEmail, userEncryptedPii, ...otherFields } = res.rows[0];
 
   const { userName, userEmail, userPhoneNumber } =

--- a/src/lib/user/actions/get-my-account.ts
+++ b/src/lib/user/actions/get-my-account.ts
@@ -10,7 +10,7 @@ export async function getMyAccount(
 ): Promise<
   Result<
     MyAccount,
-    typeof BARK_CODE.ERROR_USER_NOT_FOUND | typeof BARK_CODE.FAILURE_DB_QUERY
+    typeof BARK_CODE.ERROR_USER_NOT_FOUND | typeof BARK_CODE.DB_QUERY_FAILURE
   >
 > {
   const { userId, dbPool, userMapper } = actor.getParams();

--- a/src/lib/user/actions/get-my-account.ts
+++ b/src/lib/user/actions/get-my-account.ts
@@ -3,14 +3,14 @@ import { dbResultQuery } from "@/lib/data/db-utils";
 import { MyAccount } from "../user-models";
 import { UserResidency } from "@/lib/data/db-enums";
 import { Err, Ok, Result } from "@/lib/utilities/result";
-import { BARK_CODE } from "@/lib/utilities/bark-code";
+import { CODE } from "@/lib/utilities/bark-code";
 
 export async function getMyAccount(
   actor: UserActor,
 ): Promise<
   Result<
     MyAccount,
-    typeof BARK_CODE.ERROR_USER_NOT_FOUND | typeof BARK_CODE.DB_QUERY_FAILURE
+    typeof CODE.ERROR_USER_NOT_FOUND | typeof CODE.DB_QUERY_FAILURE
   >
 > {
   const { userId, dbPool, userMapper } = actor.getParams();
@@ -39,7 +39,7 @@ export async function getMyAccount(
     return Err(error);
   }
   if (res.rows.length !== 1) {
-    return Err(BARK_CODE.ERROR_USER_NOT_FOUND);
+    return Err(CODE.ERROR_USER_NOT_FOUND);
   }
   const { userHashedEmail, userEncryptedPii, ...otherFields } = res.rows[0];
 

--- a/src/lib/user/actions/get-my-account.ts
+++ b/src/lib/user/actions/get-my-account.ts
@@ -3,6 +3,7 @@ import { dbQuery } from "@/lib/data/db-utils";
 import { MyAccount } from "../user-models";
 import { UserResidency } from "@/lib/data/db-enums";
 
+// WIP: Change return type to Promise<MyAccount> There's no reason why zero rows should be returned.
 export async function getMyAccount(
   actor: UserActor,
 ): Promise<MyAccount | null> {

--- a/src/lib/user/actions/get-my-latest-call.ts
+++ b/src/lib/user/actions/get-my-latest-call.ts
@@ -2,14 +2,14 @@ import { UserActor } from "../user-actor";
 import { dbResultQuery } from "@/lib/data/db-utils";
 import { MyLastContactedTime } from "../user-models";
 import { Err, Ok, Result } from "@/lib/utilities/result";
-import { BARK_CODE } from "@/lib/utilities/bark-code";
+import { CODE } from "@/lib/utilities/bark-code";
 
 export async function getMyLatestCall(
   actor: UserActor,
 ): Promise<
   Result<
     MyLastContactedTime,
-    typeof BARK_CODE.ERROR_USER_NOT_FOUND | typeof BARK_CODE.DB_QUERY_FAILURE
+    typeof CODE.ERROR_USER_NOT_FOUND | typeof CODE.DB_QUERY_FAILURE
   >
 > {
   const { userId, dbPool } = actor.getParams();
@@ -35,7 +35,7 @@ export async function getMyLatestCall(
     return Err(error);
   }
   if (res.rows.length === 0) {
-    return Err(BARK_CODE.ERROR_USER_NOT_FOUND);
+    return Err(CODE.ERROR_USER_NOT_FOUND);
   }
   return Ok(res.rows[0]);
 }

--- a/src/lib/user/actions/get-my-latest-call.ts
+++ b/src/lib/user/actions/get-my-latest-call.ts
@@ -9,7 +9,7 @@ export async function getMyLatestCall(
 ): Promise<
   Result<
     MyLastContactedTime,
-    typeof BARK_CODE.ERROR_USER_NOT_FOUND | typeof BARK_CODE.FAILURE_DB_QUERY
+    typeof BARK_CODE.ERROR_USER_NOT_FOUND | typeof BARK_CODE.DB_QUERY_FAILURE
   >
 > {
   const { userId, dbPool } = actor.getParams();

--- a/src/lib/user/actions/get-my-pets.ts
+++ b/src/lib/user/actions/get-my-pets.ts
@@ -9,6 +9,7 @@ import {
   ServiceStatus,
 } from "@/lib/data/db-enums";
 
+// WIP: convert to Result with error codes
 export async function getMyPets(actor: UserActor): Promise<MyDog[]> {
   const { userId, dbPool, dogMapper } = actor.getParams();
   const sql = `

--- a/src/lib/user/actions/get-my-pets.ts
+++ b/src/lib/user/actions/get-my-pets.ts
@@ -58,6 +58,7 @@ export async function getMyPets(actor: UserActor): Promise<MyDog[]> {
     dogParticipationStatus: ParticipationStatus;
     dogAppointments: MyDogAppointment[];
   };
+  // WIP: Use dbResultQuery
   const res = await dbQuery<Row>(dbPool, sql, [userId]);
   const futureDogs = res.rows.map(async (row) => {
     const { dogEncryptedOii, ...otherFields } = row;

--- a/src/lib/user/actions/update-dog-profile.ts
+++ b/src/lib/user/actions/update-dog-profile.ts
@@ -1,8 +1,8 @@
 import {
   dbBegin,
   dbCommit,
-  dbQuery,
   dbRelease,
+  dbResultQuery,
   dbRollback,
 } from "@/lib/data/db-utils";
 import { UserActor } from "../user-actor";
@@ -12,14 +12,7 @@ import {
   dbDeleteDogVetPreferences,
   dbInsertDogVetPreference,
 } from "@/lib/data/db-dogs";
-
-// WIP: Use BARK_CODE
-type Response =
-  | "OK_UPDATED"
-  | "ERROR_REPORT_EXISTS"
-  | "ERROR_UNAUTHORIZED"
-  | "ERROR_MISSING_DOG"
-  | "FAILURE_DB_UPDATE";
+import { BARK_CODE } from "@/lib/utilities/bark-code";
 
 type Context = {
   actor: UserActor;
@@ -27,32 +20,41 @@ type Context = {
   dogProfile: DogProfile;
 };
 
-// WIP: inline the response codes
 export async function updateDogProfile(
   actor: UserActor,
   dogId: string,
   dogProfile: DogProfile,
-): Promise<Response> {
+): Promise<
+  | typeof BARK_CODE.OK
+  | typeof BARK_CODE.ERROR_CANNOT_UPDATE_FULL_PROFILE
+  | typeof BARK_CODE.ERROR_WRONG_OWNER
+  | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
+  | typeof BARK_CODE.DB_QUERY_FAILURE
+  | typeof BARK_CODE.EXCEPTION
+> {
   const { dbPool } = actor.getParams();
   const ctx: Context = { actor, dogId, dogProfile };
   const conn = await dbPool.connect();
   try {
     await dbBegin(conn);
     const ownershipCheck = await checkOwnership(conn, ctx);
-    if (ownershipCheck !== "OK") {
+    if (ownershipCheck !== BARK_CODE.OK) {
       return ownershipCheck;
     }
     const reportCheck = await checkExistingReport(conn, ctx);
-    if (reportCheck !== "OK") {
+    if (reportCheck !== BARK_CODE.OK) {
       return reportCheck;
     }
     const updateFields = await updateDogFields(conn, ctx);
-    if (updateFields !== "OK") {
+    if (updateFields !== BARK_CODE.OK) {
       return updateFields;
     }
-    updateVetPreference(conn, ctx);
+    const updatePreference = await updateVetPreference(conn, ctx);
+    if (updatePreference !== BARK_CODE.OK) {
+      return updatePreference;
+    }
     await dbCommit(conn);
-    return "OK_UPDATED";
+    return BARK_CODE.OK;
   } finally {
     await dbRollback(conn);
     await dbRelease(conn);
@@ -62,41 +64,66 @@ export async function updateDogProfile(
 async function checkOwnership(
   conn: PoolClient,
   ctx: Context,
-): Promise<"OK" | "ERROR_MISSING_DOG" | "ERROR_UNAUTHORIZED"> {
+): Promise<
+  | typeof BARK_CODE.OK
+  | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
+  | typeof BARK_CODE.ERROR_WRONG_OWNER
+  | typeof BARK_CODE.DB_QUERY_FAILURE
+> {
   const { actor, dogId, dogProfile: update } = ctx;
   const sql = `SELECT user_id as "ownerUserId" FROM dogs WHERE dog_id = $1`;
-  // WIP: Use dbResultQuery
-  const res = await dbQuery<{ ownerUserId: string }>(conn, sql, [dogId]);
-  if (res.rows.length === 0) {
-    return "ERROR_MISSING_DOG";
+  const { result, error } = await dbResultQuery<{ ownerUserId: string }>(
+    conn,
+    sql,
+    [dogId],
+  );
+  if (error !== undefined) {
+    return error;
   }
-  const { ownerUserId } = res.rows[0];
+  if (result.rows.length === 0) {
+    return BARK_CODE.ERROR_DOG_NOT_FOUND;
+  }
+  const { ownerUserId } = result.rows[0];
   const isOwner = actor.getUserId() === ownerUserId;
   if (!isOwner) {
-    return "ERROR_UNAUTHORIZED";
+    return BARK_CODE.ERROR_WRONG_OWNER;
   }
-  return "OK";
+  return BARK_CODE.OK;
 }
 
 async function checkExistingReport(
   conn: PoolClient,
   ctx: Context,
-): Promise<"OK" | "ERROR_REPORT_EXISTS"> {
+): Promise<
+  | typeof BARK_CODE.OK
+  | typeof BARK_CODE.DB_QUERY_FAILURE
+  | typeof BARK_CODE.ERROR_CANNOT_UPDATE_FULL_PROFILE
+> {
   const { dogId, dogProfile: update } = ctx;
   const sql = `SELECT COUNT(1)::integer as "numReports" FROM reports WHERE dog_id = $1`;
-  // WIP: Use dbResultQuery
-  const res = await dbQuery<{ numReports: number }>(conn, sql, [dogId]);
-  const { numReports } = res.rows[0];
-  if (numReports > 0) {
-    return "ERROR_REPORT_EXISTS";
+  const { result, error } = await dbResultQuery<{ numReports: number }>(
+    conn,
+    sql,
+    [dogId],
+  );
+  if (error !== undefined) {
+    return error;
   }
-  return "OK";
+  const { numReports } = result.rows[0];
+  if (numReports > 0) {
+    return BARK_CODE.ERROR_CANNOT_UPDATE_FULL_PROFILE;
+  }
+  return BARK_CODE.OK;
 }
 
 async function updateDogFields(
   conn: PoolClient,
   ctx: Context,
-): Promise<"OK" | "FAILURE_DB_UPDATE"> {
+): Promise<
+  | typeof BARK_CODE.OK
+  | typeof BARK_CODE.DB_QUERY_FAILURE
+  | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
+> {
   const { actor, dogId, dogProfile } = ctx;
   const { dogMapper } = actor.getParams();
   const {
@@ -128,8 +155,7 @@ async function updateDogFields(
     dog_id = $1
   RETURNING 1
   `;
-  // WIP: Use dbResultQuery
-  const res = await dbQuery(conn, sql, [
+  const { result, error } = await dbResultQuery(conn, sql, [
     dogId,
     dogEncryptedOii,
     dogBreed,
@@ -140,23 +166,28 @@ async function updateDogFields(
     dogEverPregnant,
     dogEverReceivedTransfusion,
   ]);
-  if (res.rows.length !== 1) {
-    // WIP: this should be dog not found.
-    return "FAILURE_DB_UPDATE";
+  if (error !== undefined) {
+    return error;
   }
-  return "OK";
+  if (result.rows.length !== 1) {
+    return BARK_CODE.ERROR_DOG_NOT_FOUND;
+  }
+  return BARK_CODE.OK;
 }
 
 async function updateVetPreference(
   conn: PoolClient,
   ctx: Context,
-): Promise<"OK"> {
-  const { dogId, dogProfile } = ctx;
-  const { dogPreferredVetId: vetId } = dogProfile;
-  // WIP: Catch exceptions here and interpret as ERROR_EXCEPTION
-  await dbDeleteDogVetPreferences(conn, dogId);
-  if (vetId !== "") {
-    await dbInsertDogVetPreference(conn, dogId, vetId);
+): Promise<typeof BARK_CODE.OK | typeof BARK_CODE.EXCEPTION> {
+  try {
+    const { dogId, dogProfile } = ctx;
+    const { dogPreferredVetId: vetId } = dogProfile;
+    await dbDeleteDogVetPreferences(conn, dogId);
+    if (vetId !== "") {
+      await dbInsertDogVetPreference(conn, dogId, vetId);
+    }
+    return BARK_CODE.OK;
+  } catch {
+    return BARK_CODE.EXCEPTION;
   }
-  return "OK";
 }

--- a/src/lib/user/actions/update-dog-profile.ts
+++ b/src/lib/user/actions/update-dog-profile.ts
@@ -30,7 +30,7 @@ export async function updateDogProfile(
   | typeof CODE.ERROR_WRONG_OWNER
   | typeof CODE.ERROR_DOG_NOT_FOUND
   | typeof CODE.DB_QUERY_FAILURE
-  | typeof CODE.EXCEPTION
+  | typeof CODE.FAILED
 > {
   const { dbPool } = actor.getParams();
   const ctx: Context = { actor, dogId, dogProfile };
@@ -178,7 +178,7 @@ async function updateDogFields(
 async function updateVetPreference(
   conn: PoolClient,
   ctx: Context,
-): Promise<typeof CODE.OK | typeof CODE.EXCEPTION> {
+): Promise<typeof CODE.OK | typeof CODE.FAILED> {
   try {
     const { dogId, dogProfile } = ctx;
     const { dogPreferredVetId: vetId } = dogProfile;
@@ -188,6 +188,6 @@ async function updateVetPreference(
     }
     return CODE.OK;
   } catch {
-    return CODE.EXCEPTION;
+    return CODE.FAILED;
   }
 }

--- a/src/lib/user/actions/update-dog-profile.ts
+++ b/src/lib/user/actions/update-dog-profile.ts
@@ -13,6 +13,7 @@ import {
   dbInsertDogVetPreference,
 } from "@/lib/data/db-dogs";
 
+// WIP: Use BARK_CODE
 type Response =
   | "OK_UPDATED"
   | "ERROR_REPORT_EXISTS"

--- a/src/lib/user/actions/update-dog-profile.ts
+++ b/src/lib/user/actions/update-dog-profile.ts
@@ -27,6 +27,7 @@ type Context = {
   dogProfile: DogProfile;
 };
 
+// WIP: inline the response codes
 export async function updateDogProfile(
   actor: UserActor,
   dogId: string,

--- a/src/lib/user/actions/update-dog-profile.ts
+++ b/src/lib/user/actions/update-dog-profile.ts
@@ -64,6 +64,7 @@ async function checkOwnership(
 ): Promise<"OK" | "ERROR_MISSING_DOG" | "ERROR_UNAUTHORIZED"> {
   const { actor, dogId, dogProfile: update } = ctx;
   const sql = `SELECT user_id as "ownerUserId" FROM dogs WHERE dog_id = $1`;
+  // WIP: Use dbResultQuery
   const res = await dbQuery<{ ownerUserId: string }>(conn, sql, [dogId]);
   if (res.rows.length === 0) {
     return "ERROR_MISSING_DOG";
@@ -82,6 +83,7 @@ async function checkExistingReport(
 ): Promise<"OK" | "ERROR_REPORT_EXISTS"> {
   const { dogId, dogProfile: update } = ctx;
   const sql = `SELECT COUNT(1)::integer as "numReports" FROM reports WHERE dog_id = $1`;
+  // WIP: Use dbResultQuery
   const res = await dbQuery<{ numReports: number }>(conn, sql, [dogId]);
   const { numReports } = res.rows[0];
   if (numReports > 0) {
@@ -125,6 +127,7 @@ async function updateDogFields(
     dog_id = $1
   RETURNING 1
   `;
+  // WIP: Use dbResultQuery
   const res = await dbQuery(conn, sql, [
     dogId,
     dogEncryptedOii,
@@ -137,6 +140,7 @@ async function updateDogFields(
     dogEverReceivedTransfusion,
   ]);
   if (res.rows.length !== 1) {
+    // WIP: this should be dog not found.
     return "FAILURE_DB_UPDATE";
   }
   return "OK";
@@ -148,6 +152,7 @@ async function updateVetPreference(
 ): Promise<"OK"> {
   const { dogId, dogProfile } = ctx;
   const { dogPreferredVetId: vetId } = dogProfile;
+  // WIP: Catch exceptions here and interpret as ERROR_EXCEPTION
   await dbDeleteDogVetPreferences(conn, dogId);
   if (vetId !== "") {
     await dbInsertDogVetPreference(conn, dogId, vetId);

--- a/src/lib/user/actions/update-my-account-details.ts
+++ b/src/lib/user/actions/update-my-account-details.ts
@@ -22,7 +22,7 @@ export async function updateMyAccountDetails(
 ): Promise<
   | typeof BARK_CODE.OK
   | typeof BARK_CODE.ERROR_USER_NOT_FOUND
-  | typeof BARK_CODE.FAILURE_DB_QUERY
+  | typeof BARK_CODE.DB_QUERY_FAILURE
 > {
   const ctx: Context = { actor, update };
   const { dbPool } = actor.getParams();
@@ -47,7 +47,7 @@ async function updateAccountFields(
 ): Promise<
   | typeof BARK_CODE.OK
   | typeof BARK_CODE.ERROR_USER_NOT_FOUND
-  | typeof BARK_CODE.FAILURE_DB_QUERY
+  | typeof BARK_CODE.DB_QUERY_FAILURE
 > {
   const { actor, update } = ctx;
   const { userId, userMapper } = actor.getParams();

--- a/src/lib/user/actions/update-my-account-details.ts
+++ b/src/lib/user/actions/update-my-account-details.ts
@@ -15,6 +15,7 @@ type Context = {
   update: MyAccountDetailsUpdate;
 };
 
+// WIP: Define the return type
 export async function updateMyAccountDetails(
   actor: UserActor,
   update: MyAccountDetailsUpdate,

--- a/src/lib/user/actions/update-my-account-details.ts
+++ b/src/lib/user/actions/update-my-account-details.ts
@@ -66,6 +66,7 @@ async function updateAccountFields(
     RETURNING
       1
   `;
+  // WIP: use dbResultQuery
   const res = await dbQuery(conn, sql, [
     userId,
     userResidency,
@@ -73,6 +74,7 @@ async function updateAccountFields(
   ]);
 
   if (res.rows.length !== 1) {
+    // WIP: this should be failure user not found
     return BARK_CODE.FAILED;
   }
   return BARK_CODE.OK;

--- a/src/lib/user/actions/update-my-account-details.ts
+++ b/src/lib/user/actions/update-my-account-details.ts
@@ -9,7 +9,7 @@ import { UserActor } from "../user-actor";
 import { MyAccountDetailsUpdate } from "../user-models";
 import { PoolClient } from "pg";
 import { guaranteed } from "@/lib/utilities/bark-utils";
-import { BARK_CODE } from "@/lib/utilities/bark-code";
+import { CODE } from "@/lib/utilities/bark-code";
 
 type Context = {
   actor: UserActor;
@@ -20,9 +20,9 @@ export async function updateMyAccountDetails(
   actor: UserActor,
   update: MyAccountDetailsUpdate,
 ): Promise<
-  | typeof BARK_CODE.OK
-  | typeof BARK_CODE.ERROR_USER_NOT_FOUND
-  | typeof BARK_CODE.DB_QUERY_FAILURE
+  | typeof CODE.OK
+  | typeof CODE.ERROR_USER_NOT_FOUND
+  | typeof CODE.DB_QUERY_FAILURE
 > {
   const ctx: Context = { actor, update };
   const { dbPool } = actor.getParams();
@@ -30,11 +30,11 @@ export async function updateMyAccountDetails(
   try {
     await dbBegin(conn);
     const resUpdate = await updateAccountFields(conn, ctx);
-    if (resUpdate !== BARK_CODE.OK) {
+    if (resUpdate !== CODE.OK) {
       return resUpdate;
     }
     await dbCommit(conn);
-    return BARK_CODE.OK;
+    return CODE.OK;
   } finally {
     await dbRollback(conn);
     await dbRelease(conn);
@@ -45,9 +45,9 @@ async function updateAccountFields(
   conn: PoolClient,
   ctx: Context,
 ): Promise<
-  | typeof BARK_CODE.OK
-  | typeof BARK_CODE.ERROR_USER_NOT_FOUND
-  | typeof BARK_CODE.DB_QUERY_FAILURE
+  | typeof CODE.OK
+  | typeof CODE.ERROR_USER_NOT_FOUND
+  | typeof CODE.DB_QUERY_FAILURE
 > {
   const { actor, update } = ctx;
   const { userId, userMapper } = actor.getParams();
@@ -82,7 +82,7 @@ async function updateAccountFields(
     return error;
   }
   if (result.rows.length !== 1) {
-    return BARK_CODE.ERROR_USER_NOT_FOUND;
+    return CODE.ERROR_USER_NOT_FOUND;
   }
-  return BARK_CODE.OK;
+  return CODE.OK;
 }

--- a/src/lib/user/actions/update-my-account-details.ts
+++ b/src/lib/user/actions/update-my-account-details.ts
@@ -18,6 +18,7 @@ type Context = {
 
 type ResponseCode = typeof BARK_CODE.OK | typeof BARK_CODE.FAILED;
 
+// WIP: inline the response codes
 export async function updateMyAccountDetails(
   actor: UserActor,
   update: MyAccountDetailsUpdate,

--- a/src/lib/user/actions/update-sub-profile.ts
+++ b/src/lib/user/actions/update-sub-profile.ts
@@ -64,6 +64,7 @@ async function checkOwnership(
 ): Promise<"OK" | "ERROR_MISSING_DOG" | "ERROR_UNAUTHORIZED"> {
   const { actor, dogId, subProfile } = ctx;
   const sql = `SELECT user_id as "ownerUserId" FROM dogs WHERE dog_id = $1`;
+  // WIP: use dbResultQuery
   const res = await dbQuery<{ ownerUserId: string }>(conn, sql, [dogId]);
   if (res.rows.length === 0) {
     return "ERROR_MISSING_DOG";
@@ -86,6 +87,7 @@ async function checkExistingReport(
   FROM reports
   WHERE dog_id = $1
   `;
+  // WIP: use dbResultQuery
   const res = await dbQuery<{ numReports: number }>(conn, sql, [dogId]);
   const { numReports } = res.rows[0];
   if (numReports === 0) {
@@ -117,6 +119,7 @@ async function updateDogFields(
     dog_id = $1
   RETURNING 1
   `;
+  // WIP: use dbResultQuery
   const res = await dbQuery(conn, sql, [
     dogId,
     dogEncryptedOii,
@@ -130,6 +133,7 @@ async function updateDogFields(
   return "OK";
 }
 
+// WIP: Use ERROR_EXCEPTION here
 async function updateVetPreference(
   conn: PoolClient,
   ctx: Context,

--- a/src/lib/user/actions/update-sub-profile.ts
+++ b/src/lib/user/actions/update-sub-profile.ts
@@ -27,6 +27,7 @@ type Context = {
   subProfile: SubProfile;
 };
 
+// WIP: inline the response codes
 export async function updateSubProfile(
   actor: UserActor,
   dogId: string,

--- a/src/lib/user/actions/update-sub-profile.ts
+++ b/src/lib/user/actions/update-sub-profile.ts
@@ -30,7 +30,7 @@ export async function updateSubProfile(
   | typeof CODE.ERROR_WRONG_OWNER
   | typeof CODE.ERROR_DOG_NOT_FOUND
   | typeof CODE.ERROR_SHOULD_UPDATE_FULL_PROFILE
-  | typeof CODE.EXCEPTION
+  | typeof CODE.FAILED
 > {
   const ctx: Context = { actor, dogId, subProfile };
   const { dbPool } = actor.getParams();
@@ -166,7 +166,7 @@ async function updateDogFields(
 async function updateVetPreference(
   conn: PoolClient,
   ctx: Context,
-): Promise<typeof CODE.OK | typeof CODE.EXCEPTION> {
+): Promise<typeof CODE.OK | typeof CODE.FAILED> {
   try {
     const { dogId, subProfile } = ctx;
     const { dogPreferredVetId: vetId } = subProfile;
@@ -176,6 +176,6 @@ async function updateVetPreference(
     }
     return CODE.OK;
   } catch {
-    return CODE.EXCEPTION;
+    return CODE.FAILED;
   }
 }

--- a/src/lib/user/actions/update-sub-profile.ts
+++ b/src/lib/user/actions/update-sub-profile.ts
@@ -13,6 +13,7 @@ import {
   dbInsertDogVetPreference,
 } from "@/lib/data/db-dogs";
 
+// WIP: Use BARK_CODE
 type Response =
   | "OK_UPDATED"
   | "ERROR_UNAUTHORIZED"

--- a/src/lib/user/actions/update-sub-profile.ts
+++ b/src/lib/user/actions/update-sub-profile.ts
@@ -12,7 +12,7 @@ import {
   dbDeleteDogVetPreferences,
   dbInsertDogVetPreference,
 } from "@/lib/data/db-dogs";
-import { BARK_CODE } from "@/lib/utilities/bark-code";
+import { CODE } from "@/lib/utilities/bark-code";
 
 type Context = {
   actor: UserActor;
@@ -25,12 +25,12 @@ export async function updateSubProfile(
   dogId: string,
   subProfile: SubProfile,
 ): Promise<
-  | typeof BARK_CODE.OK
-  | typeof BARK_CODE.DB_QUERY_FAILURE
-  | typeof BARK_CODE.ERROR_WRONG_OWNER
-  | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
-  | typeof BARK_CODE.ERROR_SHOULD_UPDATE_FULL_PROFILE
-  | typeof BARK_CODE.EXCEPTION
+  | typeof CODE.OK
+  | typeof CODE.DB_QUERY_FAILURE
+  | typeof CODE.ERROR_WRONG_OWNER
+  | typeof CODE.ERROR_DOG_NOT_FOUND
+  | typeof CODE.ERROR_SHOULD_UPDATE_FULL_PROFILE
+  | typeof CODE.EXCEPTION
 > {
   const ctx: Context = { actor, dogId, subProfile };
   const { dbPool } = actor.getParams();
@@ -38,23 +38,23 @@ export async function updateSubProfile(
   try {
     await dbBegin(conn);
     const resOwnership = await checkOwnership(conn, ctx);
-    if (resOwnership !== BARK_CODE.OK) {
+    if (resOwnership !== CODE.OK) {
       return resOwnership;
     }
     const resCheckReports = await checkExistingReport(conn, ctx);
-    if (resCheckReports !== BARK_CODE.OK) {
+    if (resCheckReports !== CODE.OK) {
       return resCheckReports;
     }
     const resUpdate = await updateDogFields(conn, ctx);
-    if (resUpdate !== BARK_CODE.OK) {
+    if (resUpdate !== CODE.OK) {
       return resUpdate;
     }
     const resPref = await updateVetPreference(conn, ctx);
-    if (resPref !== BARK_CODE.OK) {
+    if (resPref !== CODE.OK) {
       return resPref;
     }
     await dbCommit(conn);
-    return BARK_CODE.OK;
+    return CODE.OK;
   } finally {
     await dbRollback(conn);
     await dbRelease(conn);
@@ -65,10 +65,10 @@ async function checkOwnership(
   conn: PoolClient,
   ctx: Context,
 ): Promise<
-  | typeof BARK_CODE.OK
-  | typeof BARK_CODE.DB_QUERY_FAILURE
-  | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
-  | typeof BARK_CODE.ERROR_WRONG_OWNER
+  | typeof CODE.OK
+  | typeof CODE.DB_QUERY_FAILURE
+  | typeof CODE.ERROR_DOG_NOT_FOUND
+  | typeof CODE.ERROR_WRONG_OWNER
 > {
   const { actor, dogId, subProfile } = ctx;
   const sql = `SELECT user_id as "ownerUserId" FROM dogs WHERE dog_id = $1`;
@@ -81,23 +81,23 @@ async function checkOwnership(
     return error;
   }
   if (result.rows.length === 0) {
-    return BARK_CODE.ERROR_DOG_NOT_FOUND;
+    return CODE.ERROR_DOG_NOT_FOUND;
   }
   const { ownerUserId } = result.rows[0];
   const isOwner = actor.getUserId() === ownerUserId;
   if (!isOwner) {
-    return BARK_CODE.ERROR_WRONG_OWNER;
+    return CODE.ERROR_WRONG_OWNER;
   }
-  return BARK_CODE.OK;
+  return CODE.OK;
 }
 
 async function checkExistingReport(
   conn: PoolClient,
   ctx: Context,
 ): Promise<
-  | typeof BARK_CODE.OK
-  | typeof BARK_CODE.DB_QUERY_FAILURE
-  | typeof BARK_CODE.ERROR_SHOULD_UPDATE_FULL_PROFILE
+  | typeof CODE.OK
+  | typeof CODE.DB_QUERY_FAILURE
+  | typeof CODE.ERROR_SHOULD_UPDATE_FULL_PROFILE
 > {
   const { dogId, subProfile } = ctx;
   const sql = `
@@ -115,18 +115,18 @@ async function checkExistingReport(
   }
   const { numReports } = result.rows[0];
   if (numReports === 0) {
-    return BARK_CODE.ERROR_SHOULD_UPDATE_FULL_PROFILE;
+    return CODE.ERROR_SHOULD_UPDATE_FULL_PROFILE;
   }
-  return BARK_CODE.OK;
+  return CODE.OK;
 }
 
 async function updateDogFields(
   conn: PoolClient,
   ctx: Context,
 ): Promise<
-  | typeof BARK_CODE.OK
-  | typeof BARK_CODE.DB_QUERY_FAILURE
-  | typeof BARK_CODE.ERROR_DOG_NOT_FOUND
+  | typeof CODE.OK
+  | typeof CODE.DB_QUERY_FAILURE
+  | typeof CODE.ERROR_DOG_NOT_FOUND
 > {
   const { dogId, subProfile, actor } = ctx;
   const { dogMapper } = actor.getParams();
@@ -158,15 +158,15 @@ async function updateDogFields(
     return error;
   }
   if (result.rows.length !== 1) {
-    return BARK_CODE.ERROR_DOG_NOT_FOUND;
+    return CODE.ERROR_DOG_NOT_FOUND;
   }
-  return BARK_CODE.OK;
+  return CODE.OK;
 }
 
 async function updateVetPreference(
   conn: PoolClient,
   ctx: Context,
-): Promise<typeof BARK_CODE.OK | typeof BARK_CODE.EXCEPTION> {
+): Promise<typeof CODE.OK | typeof CODE.EXCEPTION> {
   try {
     const { dogId, subProfile } = ctx;
     const { dogPreferredVetId: vetId } = subProfile;
@@ -174,8 +174,8 @@ async function updateVetPreference(
     if (vetId !== "") {
       await dbInsertDogVetPreference(conn, dogId, vetId);
     }
-    return BARK_CODE.OK;
+    return CODE.OK;
   } catch {
-    return BARK_CODE.EXCEPTION;
+    return CODE.EXCEPTION;
   }
 }

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -1,5 +1,5 @@
 /**
- * Standard codes for actor actions and server actions.
+ * Standard error or response codes.
  */
 export const CODE = {
   /**

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -14,6 +14,16 @@ export const CODE = {
   FAILED: "FAILED",
 
   /**
+   * When an attempt is made to register an account that already exists.
+   */
+  ERROR_ACCOUNT_ALREADY_EXISTS: "ERROR_ACCOUNT_ALREADY_EXISTS",
+
+  /**
+   * When OTP is invalid.
+   */
+  ERROR_INVALID_OTP: "ERROR_INVALID_OTP",
+
+  /**
    * When the caller is not logged-in at all or as the wrong correct account
    * type.
    */

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -8,12 +8,6 @@ export const BARK_CODE = {
   OK: "OK",
 
   /**
-   * When an operation failed for server related reasons. Conceptually, this
-   * maps to a 500 server error.
-   */
-  FAILED: "FAILED",
-
-  /**
    * When the caller is not logged-in at all or as the wrong correct account
    * type.
    */
@@ -36,4 +30,15 @@ export const BARK_CODE = {
    * the user is not the owner of the dog.
    */
   ERROR_WRONG_OWNER: "ERROR_WRONG_OWNER",
+
+  /**
+   * When a database query failed.
+   */
+  FAILURE_DB_QUERY: "FAILURE_DB_QUERY",
+
+  /**
+   * When an operation failed for server related reasons. Conceptually, this
+   * maps to a 500 server error.
+   */
+  FAILED: "FAILED",
 } as const;

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -13,6 +13,11 @@ export const CODE = {
   FAILED: "FAILED",
 
   /**
+   * When an expected account cannot be found. e.g. when sending OTP.
+   */
+  ERROR_ACCOUNT_NOT_FOUND: "ERROR_ACCOUNT_NOT_FOUND",
+
+  /**
    * When an attempt is made to register an account that already exists.
    */
   ERROR_ACCOUNT_ALREADY_EXISTS: "ERROR_ACCOUNT_ALREADY_EXISTS",

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -8,6 +8,11 @@ export const BARK_CODE = {
   OK: "OK",
 
   /**
+   * When an operation failed and there is no more detail than that.
+   */
+  FAILED: "FAILED",
+
+  /**
    * When the caller is not logged-in at all or as the wrong correct account
    * type.
    */
@@ -36,10 +41,4 @@ export const BARK_CODE = {
    * When a database query failed.
    */
   FAILURE_DB_QUERY: "FAILURE_DB_QUERY",
-
-  // WIP: Rename to ERROR_EXCEPTION
-  /**
-   * When an exception is caught.
-   */
-  FAILED: "FAILED",
 } as const;

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -68,10 +68,4 @@ export const CODE = {
    * When a database query failed.
    */
   DB_QUERY_FAILURE: "DB_QUERY_FAILURE",
-
-  /**
-   * An exception happned.
-   */
-  // WIP: just use FAILED.
-  EXCEPTION: "EXCEPTION",
 } as const;

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -10,6 +10,7 @@ export const BARK_CODE = {
   /**
    * When an operation failed and there is no more detail than that.
    */
+  // WIP: some of these are exceptions.
   FAILED: "FAILED",
 
   /**
@@ -37,7 +38,25 @@ export const BARK_CODE = {
   ERROR_WRONG_OWNER: "ERROR_WRONG_OWNER",
 
   /**
+   * When an attempt is made to update a full profile but it is not allowed.
+   * Full profile updates are allowed only before the first medical report is
+   * received.
+   */
+  ERROR_CANNOT_UPDATE_FULL_PROFILE: "ERROR_CANNOT_UPDATE_FULL_PROFILE",
+
+  /**
+   * When an attempt is made to update a sub profile, but caller should be
+   * updating the full profile instead.
+   */
+  ERROR_SHOULD_UPDATE_FULL_PROFILE: "ERROR_SHOULD_UPDATE_FULL_PROFILE",
+
+  /**
    * When a database query failed.
    */
   DB_QUERY_FAILURE: "DB_QUERY_FAILURE",
+
+  /**
+   * An exception happned.
+   */
+  EXCEPTION: "EXCEPTION",
 } as const;

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -1,0 +1,33 @@
+/**
+ * Standard codes for actor actions and server actions.
+ */
+export const BARK_CODE = {
+  /**
+   * Success
+   */
+  OK: "OK",
+
+  /**
+   * When an operation failed for server related reasons. Conceptually, this
+   * maps to a 500 server error.
+   */
+  FAILED: "FAILED",
+
+  /**
+   * When the caller is not logged-in at all or as the wrong correct account
+   * type.
+   */
+  ERROR_NOT_LOGGED_IN: "ERROR_NOT_LOGGED_IN",
+
+  /**
+   * When the operation is for a specified dog (typically by dogId), but there
+   * is no such dog.
+   */
+  ERROR_DOG_NOT_FOUND: "ERROR_DOG_NOT_FOUND",
+
+  /**
+   * When a user actor attempts to retrieve or mutate a dog related record, but
+   * the user is not the owner of the dog.
+   */
+  ERROR_WRONG_OWNER: "ERROR_WRONG_OWNER",
+} as const;

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -36,9 +36,8 @@ export const BARK_CODE = {
    */
   ERROR_WRONG_OWNER: "ERROR_WRONG_OWNER",
 
-  // WIP: Change to ERROR_DB_QUERY
   /**
    * When a database query failed.
    */
-  FAILURE_DB_QUERY: "FAILURE_DB_QUERY",
+  DB_QUERY_FAILURE: "DB_QUERY_FAILURE",
 } as const;

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -31,14 +31,15 @@ export const BARK_CODE = {
    */
   ERROR_WRONG_OWNER: "ERROR_WRONG_OWNER",
 
+  // WIP: Change to ERROR_DB_QUERY
   /**
    * When a database query failed.
    */
   FAILURE_DB_QUERY: "FAILURE_DB_QUERY",
 
+  // WIP: Rename to ERROR_EXCEPTION
   /**
-   * When an operation failed for server related reasons. Conceptually, this
-   * maps to a 500 server error.
+   * When an exception is caught.
    */
   FAILED: "FAILED",
 } as const;

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -10,7 +10,6 @@ export const CODE = {
   /**
    * When an operation failed and there is no more detail than that.
    */
-  // WIP: some of these are exceptions.
   FAILED: "FAILED",
 
   /**
@@ -68,5 +67,6 @@ export const CODE = {
   /**
    * An exception happned.
    */
+  // WIP: just use FAILED.
   EXCEPTION: "EXCEPTION",
 } as const;

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -20,6 +20,12 @@ export const BARK_CODE = {
   ERROR_NOT_LOGGED_IN: "ERROR_NOT_LOGGED_IN",
 
   /**
+   * When the operation needs to retrieve a specified user, but there is no such
+   * user on record.
+   */
+  ERROR_USER_NOT_FOUND: "ERROR_USER_NOT_FOUND",
+
+  /**
    * When the operation is for a specified dog (typically by dogId), but there
    * is no such dog.
    */

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -1,7 +1,7 @@
 /**
  * Standard codes for actor actions and server actions.
  */
-export const BARK_CODE = {
+export const CODE = {
   /**
    * Success
    */

--- a/tests/services/email-otp-service.test.ts
+++ b/tests/services/email-otp-service.test.ts
@@ -4,34 +4,34 @@ import { getEmailOtpService, insertUser, userPii } from "../_fixtures";
 import { HarnessEmailService, HarnessFailureEmailService } from "../_harness";
 
 describe("EmailOtpService::sendOtp", () => {
-  it("should return NO_ACCOUNT when email is not an existing user account", async () => {
+  it("should return ERROR_ACCOUNT_NOT_FOUND when email is not an existing user account", async () => {
     await withDb(async (dbPool) => {
       const service = getEmailOtpService(dbPool);
       const res = await service.sendOtp({
         emailAddress: "nouser@user.com",
         accountType: AccountType.USER,
       });
-      expect(res).toEqual("NO_ACCOUNT");
+      expect(res).toEqual("ERROR_ACCOUNT_NOT_FOUND");
     });
   });
-  it("should return NO_ACCOUNT when email is not an existing vet account", async () => {
+  it("should return ERROR_ACCOUNT_NOT_FOUND when email is not an existing vet account", async () => {
     await withDb(async (dbPool) => {
       const service = getEmailOtpService(dbPool);
       const res = await service.sendOtp({
         emailAddress: "novet@vet.com",
         accountType: AccountType.VET,
       });
-      expect(res).toEqual("NO_ACCOUNT");
+      expect(res).toEqual("ERROR_ACCOUNT_NOT_FOUND");
     });
   });
-  it("should return NO_ACCOUNT when email is not an existing admin account", async () => {
+  it("should return ERROR_ACCOUNT_NOT_FOUND when email is not an existing admin account", async () => {
     await withDb(async (dbPool) => {
       const service = getEmailOtpService(dbPool);
       const res = await service.sendOtp({
         emailAddress: "noadmin@admin.com",
         accountType: AccountType.ADMIN,
       });
-      expect(res).toEqual("NO_ACCOUNT");
+      expect(res).toEqual("ERROR_ACCOUNT_NOT_FOUND");
     });
   });
   it("should return OK when account type is null", async () => {
@@ -45,7 +45,7 @@ describe("EmailOtpService::sendOtp", () => {
       expect(res).toEqual("OK");
     });
   });
-  it("should return SEND_FAILED when email failed to send", async () => {
+  it("should return FAILED when email failed to send", async () => {
     await withDb(async (dbPool) => {
       const service = getEmailOtpService(dbPool, {
         emailService: new HarnessFailureEmailService(),
@@ -56,7 +56,7 @@ describe("EmailOtpService::sendOtp", () => {
         emailAddress: userEmail,
         accountType: AccountType.USER,
       });
-      expect(res).toEqual("SEND_FAILED");
+      expect(res).toEqual("FAILED");
     });
   });
   it("should return OK when email was sent", async () => {

--- a/tests/services/registration.test.ts
+++ b/tests/services/registration.test.ts
@@ -28,7 +28,7 @@ import { HarnessOtpService } from "../_harness";
 import { dbQuery } from "@/lib/data/db-utils";
 
 describe("RegistrationHandler", () => {
-  it("should return STATUS_201_CREATED when user account is successfully created", async () => {
+  it("should return OK when user account is successfully created", async () => {
     await withDb(async (dbPool) => {
       // GIVEN a standard request
       const preferredVet = await insertVet(42, dbPool);
@@ -40,7 +40,7 @@ describe("RegistrationHandler", () => {
       const response = await handler.handle(request);
 
       // THEN
-      expect(response).toEqual("STATUS_201_CREATED");
+      expect(response).toEqual("OK");
 
       // AND a user should be created
       const userHashedEmail = await config.emailHashService.getHashHex(
@@ -78,7 +78,7 @@ describe("RegistrationHandler", () => {
     });
   });
 
-  it("should return STATUS_401_INVALID_OTP when OTP is invalid", async () => {
+  it("should return ERROR_INVALID_OTP when OTP is invalid", async () => {
     await withDb(async (dbPool) => {
       // GIVEN a request with invalid OTP
       const preferredVet = await insertVet(42, dbPool);
@@ -92,7 +92,7 @@ describe("RegistrationHandler", () => {
       const response = await handler.handle(request);
 
       // THEN
-      expect(response).toEqual("STATUS_401_INVALID_OTP");
+      expect(response).toEqual("ERROR_INVALID_OTP");
 
       // AND no records created
       const resUsers = await dbQuery(dbPool, `SELECT 1 FROM users`, []);
@@ -108,7 +108,7 @@ describe("RegistrationHandler", () => {
     });
   });
 
-  it("should return STATUS_409_USER_EXISTS when user already exists", async () => {
+  it("should return ERROR_ACCOUNT_ALREADY_EXISTS when user already exists", async () => {
     await withDb(async (dbPool) => {
       // GIVEN a request for a user that already exists
       const preferredVet = await insertVet(42, dbPool);
@@ -125,13 +125,13 @@ describe("RegistrationHandler", () => {
       const response = await handler.handle(request);
 
       // THEN
-      expect(response).toEqual("STATUS_409_USER_EXISTS");
+      expect(response).toEqual("ERROR_ACCOUNT_ALREADY_EXISTS");
     });
   });
 });
 
 describe("RegistrationHandler without vet id", () => {
-  it("should return STATUS_201_CREATED when user account is successfully created", async () => {
+  it("should return OK when user account is successfully created", async () => {
     await withDb(async (dbPool) => {
       // GIVEN a standard request
       const request = getRegistrationRequest(undefined);
@@ -142,7 +142,7 @@ describe("RegistrationHandler without vet id", () => {
       const response = await handler.handle(request);
 
       // THEN
-      expect(response).toEqual("STATUS_201_CREATED");
+      expect(response).toEqual("OK");
 
       // AND a user should be created
       const userHashedEmail = await config.emailHashService.getHashHex(

--- a/tests/user/get-dog-profile.test.ts
+++ b/tests/user/get-dog-profile.test.ts
@@ -19,7 +19,7 @@ import {
 import { MILLIS_PER_DAY } from "@/lib/utilities/bark-millis";
 
 describe("getDogProfile", () => {
-  it("should return ERROR_UNAUTHORIZED when user does not own the dog requested", async () => {
+  it("should return ERROR_WRONG_OWNER when user does not own the dog requested", async () => {
     await withDb(async (dbPool) => {
       // Given user u1 owns d1
       const u1 = await insertUser(1, dbPool);
@@ -31,11 +31,11 @@ describe("getDogProfile", () => {
       const { result, error } = await getDogProfile(u2Actor, d1.dogId);
 
       // Then
-      expect(error).toEqual("ERROR_UNAUTHORIZED");
+      expect(error).toEqual("ERROR_WRONG_OWNER");
       expect(result).toBeUndefined();
     });
   });
-  it("should return ERROR_MISSING_DOG when dog does not exist", async () => {
+  it("should return ERROR_DOG_NOT_FOUND when dog does not exist", async () => {
     await withDb(async (dbPool) => {
       // Given u1
       const u1 = await insertUser(1, dbPool);
@@ -46,7 +46,7 @@ describe("getDogProfile", () => {
       const { result, error } = await getDogProfile(actor, noSuchDogId);
 
       // Then
-      expect(error).toEqual("ERROR_MISSING_DOG");
+      expect(error).toEqual("ERROR_DOG_NOT_FOUND");
       expect(result).toBeUndefined();
     });
   });

--- a/tests/user/get-dog-statuses.test.ts
+++ b/tests/user/get-dog-statuses.test.ts
@@ -13,7 +13,7 @@ import {
 import { dateAgo } from "../_time_helpers";
 
 describe("getDogStatuses", () => {
-  it("should return ERROR_UNAUTHORIZED when the user does not own the requested dog", async () => {
+  it("should return ERROR_WRONG_OWNER when the user does not own the requested dog", async () => {
     await withDb(async (dbPool) => {
       const u1 = await insertUser(1, dbPool);
       const u2 = await insertUser(2, dbPool);
@@ -21,17 +21,17 @@ describe("getDogStatuses", () => {
       const actor = getUserActor(dbPool, u1.userId);
       const { result, error } = await getDogStatuses(actor, d3.dogId);
       expect(result).toBeUndefined();
-      expect(error).toEqual("ERROR_UNAUTHORIZED");
+      expect(error).toEqual("ERROR_WRONG_OWNER");
     });
   });
-  it("should return ERROR_MISSING_DOG when the requested dog does not exist", async () => {
+  it("should return ERROR_DOG_NOT_FOUND when the requested dog does not exist", async () => {
     await withDb(async (dbPool) => {
       const u1 = await insertUser(1, dbPool);
       const noSuchDogId = "1234567";
       const actor = getUserActor(dbPool, u1.userId);
       const { result, error } = await getDogStatuses(actor, noSuchDogId);
       expect(result).toBeUndefined();
-      expect(error).toEqual("ERROR_MISSING_DOG");
+      expect(error).toEqual("ERROR_DOG_NOT_FOUND");
     });
   });
   it("should return statuses of the requested dog", async () => {

--- a/tests/user/get-my-account.test.ts
+++ b/tests/user/get-my-account.test.ts
@@ -9,10 +9,11 @@ describe("getMyAccount", () => {
     await withDb(async (dbPool) => {
       const { userId } = await insertUser(1, dbPool);
       const actor = getUserActor(dbPool, userId);
-      const account = await getMyAccount(actor);
+
+      const { result: account, error } = await getMyAccount(actor);
+      expect(error).toBeUndefined();
 
       const { userName, userEmail, userPhoneNumber, ...otherFields } = account!;
-
       expect(otherFields.userCreationTime).toBeDefined();
       expect(userName).toEqual("User 1");
       expect(userEmail).toEqual("user1@user.com");
@@ -20,12 +21,12 @@ describe("getMyAccount", () => {
       expect(userPhoneNumber).toEqual("+65 10000001");
     });
   });
-  it("should fail if the user does not exist", async () => {
+  it("should return ERROR_USER_NOT_FOUND if the user does not exist", async () => {
     await withDb(async (dbPool) => {
       const actor = getUserActor(dbPool, "99999999");
-      await expectError(async () => {
-        await getMyAccount(actor);
-      });
+      const { result, error } = await getMyAccount(actor);
+      expect(result).toBeUndefined();
+      expect(error).toEqual("ERROR_USER_NOT_FOUND");
     });
   });
 });

--- a/tests/user/get-my-account.test.ts
+++ b/tests/user/get-my-account.test.ts
@@ -2,6 +2,7 @@ import { getMyAccount } from "@/lib/user/actions/get-my-account";
 import { withDb } from "../_db_helpers";
 import { getUserActor, insertUser } from "../_fixtures";
 import { USER_RESIDENCY } from "@/lib/data/db-enums";
+import { expectError } from "../_helpers";
 
 describe("getMyAccount", () => {
   it("should return the correct user details", async () => {
@@ -19,11 +20,12 @@ describe("getMyAccount", () => {
       expect(userPhoneNumber).toEqual("+65 10000001");
     });
   });
-  it("should return null if the user does not exist", async () => {
+  it("should fail if the user does not exist", async () => {
     await withDb(async (dbPool) => {
       const actor = getUserActor(dbPool, "99999999");
-      const account = await getMyAccount(actor);
-      expect(account).toBeNull();
+      await expectError(async () => {
+        await getMyAccount(actor);
+      });
     });
   });
 });

--- a/tests/user/get-my-latest-call.test.ts
+++ b/tests/user/get-my-latest-call.test.ts
@@ -31,10 +31,13 @@ describe("getMyLatestCall", () => {
       jest.setSystemTime(currentTime);
       await insertCall(dbPool, dogId, vetId, "APPOINTMENT");
 
-      const call = await getMyLatestCall(getUserActor(dbPool, userId));
+      const { result, error } = await getMyLatestCall(
+        getUserActor(dbPool, userId),
+      );
+      expect(error).toBeUndefined();
 
       expect(
-        currentTime.getTime() - call?.userLastContactedTime?.getTime()!,
+        currentTime.getTime() - result?.userLastContactedTime?.getTime()!,
       ).toBeLessThan(1000);
     });
   });
@@ -53,10 +56,13 @@ describe("getMyLatestCall", () => {
       jest.setSystemTime(currentTime);
       await insertCall(dbPool, dogId2, vetId, "OPT_OUT");
 
-      const call = await getMyLatestCall(getUserActor(dbPool, userId));
+      const { result, error } = await getMyLatestCall(
+        getUserActor(dbPool, userId),
+      );
+      expect(error).toBeUndefined();
 
       expect(
-        currentTime.getTime() - call?.userLastContactedTime?.getTime()!,
+        currentTime.getTime() - result?.userLastContactedTime?.getTime()!,
       ).toBeLessThan(1000);
     });
   });
@@ -64,8 +70,11 @@ describe("getMyLatestCall", () => {
     await withDb(async (dbPool) => {
       const { userId } = await insertUser(1, dbPool);
       await insertDog(1, userId, dbPool);
-      const call = await getMyLatestCall(getUserActor(dbPool, userId));
-      expect(call?.userLastContactedTime).toBeNull();
+      const { result, error } = await getMyLatestCall(
+        getUserActor(dbPool, userId),
+      );
+      expect(error).toBeUndefined();
+      expect(result?.userLastContactedTime).toBeNull();
     });
   });
 });

--- a/tests/user/get-my-pets.test.ts
+++ b/tests/user/get-my-pets.test.ts
@@ -18,7 +18,8 @@ describe("getMyPets", () => {
     await withDb(async (dbPool) => {
       const { userId } = await insertUser(34, dbPool);
       const actor = getUserActor(dbPool, userId);
-      const dogs = await getMyPets(actor);
+      const { result: dogs, error } = await getMyPets(actor);
+      expect(error).toBeUndefined();
       expect(dogs).toEqual([]);
     });
   });
@@ -28,8 +29,9 @@ describe("getMyPets", () => {
       await insertDog(2, userId, dbPool);
       await insertDog(3, userId, dbPool);
       const actor = getUserActor(dbPool, userId);
-      const dogs = await getMyPets(actor);
-      const receivedName = dogs.map((dog) => dog.dogName);
+      const { result: dogs, error } = await getMyPets(actor);
+      expect(error).toBeUndefined();
+      const receivedName = dogs!.map((dog) => dog.dogName);
       const expectedNames = await Promise.all(
         [2, 3].map(async (idx) => {
           const oii = await getDogOii(idx);
@@ -51,8 +53,9 @@ describe("getMyPets", () => {
         CALL_OUTCOME.APPOINTMENT,
       );
       const actor = getUserActor(dbPool, userId);
-      const dogs = await getMyPets(actor);
-      expect(guaranteed(dogs[0].dogAppointments[0]).vetName).toEqual(vetName);
+      const { result: dogs, error } = await getMyPets(actor);
+      expect(error).toBeUndefined();
+      expect(guaranteed(dogs![0].dogAppointments[0]).vetName).toEqual(vetName);
     });
   });
   it("should NOT return appointment details when the report has been submitted", async () => {
@@ -68,8 +71,9 @@ describe("getMyPets", () => {
       );
       const { reportId } = await insertReport(dbPool, callId);
       const actor = getUserActor(dbPool, userId);
-      const dogs = await getMyPets(actor);
-      expect(dogs[0].dogAppointments).toEqual([]);
+      const { result: dogs, error } = await getMyPets(actor);
+      expect(error).toBeUndefined();
+      expect(dogs![0].dogAppointments).toEqual([]);
     });
   });
   it("should return PAUSED dog when pause has not expired", async () => {
@@ -88,8 +92,9 @@ describe("getMyPets", () => {
         [dogId, tomorrow],
       );
       const actor = getUserActor(dbPool, userId);
-      const dogs = await getMyPets(actor);
-      expect(dogs[0].dogParticipationStatus).toEqual(
+      const { result: dogs, error } = await getMyPets(actor);
+      expect(error).toBeUndefined();
+      expect(dogs![0].dogParticipationStatus).toEqual(
         PARTICIPATION_STATUS.PAUSED,
       );
     });
@@ -110,8 +115,9 @@ describe("getMyPets", () => {
         [dogId, yesterday],
       );
       const actor = getUserActor(dbPool, userId);
-      const dogs = await getMyPets(actor);
-      expect(dogs[0].dogParticipationStatus).toEqual(
+      const { result: dogs, error } = await getMyPets(actor);
+      expect(error).toBeUndefined();
+      expect(dogs![0].dogParticipationStatus).toEqual(
         PARTICIPATION_STATUS.PARTICIPATING,
       );
     });

--- a/tests/user/update-dog-profile.test.ts
+++ b/tests/user/update-dog-profile.test.ts
@@ -20,7 +20,7 @@ import {
 import { dbInsertDogVetPreference } from "@/lib/data/db-dogs";
 
 describe("updateDogProfile", () => {
-  it("should return OK_UPDATED when update was successful", async () => {
+  it("should return OK when update was successful", async () => {
     await withDb(async (dbPool) => {
       // GIVEN users u1 with dog d1 and preferred vet v1
       const u1 = await insertUser(1, dbPool);
@@ -39,7 +39,7 @@ describe("updateDogProfile", () => {
       const res = await updateDogProfile(actor1, d1.dogId, update);
 
       // THEN
-      expect(res).toEqual("OK_UPDATED");
+      expect(res).toEqual("OK");
       const { dogProfile, profileModificationTime } = await fetchDogInfo(
         dbPool,
         d1.dogId,
@@ -50,7 +50,7 @@ describe("updateDogProfile", () => {
       );
     });
   });
-  it("should return ERROR_REPORT_EXISTS when there is an existing report for the dog", async () => {
+  it("should return ERROR_CANNOT_UPDATE_FULL_PROFILE when there is an existing report for the dog", async () => {
     await withDb(async (dbPool) => {
       // GIVEN users u1 with dog d1 with report
       const u1 = await insertUser(1, dbPool);
@@ -70,10 +70,10 @@ describe("updateDogProfile", () => {
       const res = await updateDogProfile(actor1, d1.dogId, _getDogProfile());
 
       // THEN
-      expect(res).toEqual("ERROR_REPORT_EXISTS");
+      expect(res).toEqual("ERROR_CANNOT_UPDATE_FULL_PROFILE");
     });
   });
-  it("should return ERROR_UNAUTHORIZED when the user is not the dog owner", async () => {
+  it("should return ERROR_WRONG_OWNER when the user is not the dog owner", async () => {
     await withDb(async (dbPool) => {
       // GIVEN users u1 and u2
       const u1 = await insertUser(1, dbPool);
@@ -87,10 +87,10 @@ describe("updateDogProfile", () => {
       const res = await updateDogProfile(actor1, d2.dogId, _getDogProfile());
 
       // THEN
-      expect(res).toEqual("ERROR_UNAUTHORIZED");
+      expect(res).toEqual("ERROR_WRONG_OWNER");
     });
   });
-  it("should return ERROR_MISSING_DOG when the dog does not exist", async () => {
+  it("should return ERROR_DOG_NOT_FOUND when the dog does not exist", async () => {
     await withDb(async (dbPool) => {
       // GIVEN users u1 with no dog
       const u1 = await insertUser(1, dbPool);
@@ -105,7 +105,7 @@ describe("updateDogProfile", () => {
       );
 
       // THEN
-      expect(res).toEqual("ERROR_MISSING_DOG");
+      expect(res).toEqual("ERROR_DOG_NOT_FOUND");
     });
   });
 });

--- a/tests/user/update-my-user-account-details.test.ts
+++ b/tests/user/update-my-user-account-details.test.ts
@@ -20,10 +20,10 @@ describe("updateMyAccountDetails", () => {
       const res = await updateMyAccountDetails(actor, update);
       expect(res).toEqual("OK");
 
-      const account = await getMyAccount(actor);
-      // console.log(JSON.stringify(account));
-      const { userName, userPhoneNumber, userResidency } = account!;
+      const { result: account, error } = await getMyAccount(actor);
+      expect(error).toBeUndefined();
 
+      const { userName, userPhoneNumber, userResidency } = account!;
       expect(userName).toEqual(update.userName);
       expect(userPhoneNumber).toEqual(update.userPhoneNumber);
       expect(userResidency).toEqual(update.userResidency);

--- a/tests/user/update-my-user-account-details.test.ts
+++ b/tests/user/update-my-user-account-details.test.ts
@@ -21,7 +21,7 @@ describe("updateMyAccountDetails", () => {
       expect(res).toEqual("OK_UPDATED");
 
       const account = await getMyAccount(actor);
-      console.log(JSON.stringify(account));
+      // console.log(JSON.stringify(account));
       const { userName, userPhoneNumber, userResidency } = account!;
 
       expect(userName).toEqual(update.userName);

--- a/tests/user/update-my-user-account-details.test.ts
+++ b/tests/user/update-my-user-account-details.test.ts
@@ -18,7 +18,7 @@ describe("updateMyAccountDetails", () => {
       };
 
       const res = await updateMyAccountDetails(actor, update);
-      expect(res).toEqual("OK_UPDATED");
+      expect(res).toEqual("OK");
 
       const account = await getMyAccount(actor);
       // console.log(JSON.stringify(account));

--- a/tests/user/update-sub-profile.test.ts
+++ b/tests/user/update-sub-profile.test.ts
@@ -14,7 +14,7 @@ import { updateSubProfile } from "@/lib/user/actions/update-sub-profile";
 import { dbInsertDogVetPreference } from "@/lib/data/db-dogs";
 
 describe("updateSubProfile", () => {
-  it("should return OK_UPDATED when successfully updated dog details", async () => {
+  it("should return OK when successfully updated dog details", async () => {
     await withDb(async (dbPool) => {
       // GIVEN users u1 with dog d1 and preferred vet v1
       const u1 = await insertUser(1, dbPool);
@@ -41,7 +41,7 @@ describe("updateSubProfile", () => {
       const res = await updateSubProfile(actor1, d1.dogId, update);
 
       // THEN
-      expect(res).toEqual("OK_UPDATED");
+      expect(res).toEqual("OK");
       const { subProfile, profileModificationTime } = await fetchDogInfo(
         dbPool,
         d1.dogId,
@@ -52,7 +52,7 @@ describe("updateSubProfile", () => {
       );
     });
   });
-  it("should return ERROR_UNAUTHORIZED when user does not own the dog", async () => {
+  it("should return ERROR_WRONG_OWNER when user does not own the dog", async () => {
     await withDb(async (dbPool) => {
       const u1 = await insertUser(1, dbPool);
       const d1 = await insertDog(1, u1.userId, dbPool);
@@ -62,27 +62,27 @@ describe("updateSubProfile", () => {
       const update = _getSubProfile();
       const actor = getUserActor(dbPool, u2.userId);
       const res = await updateSubProfile(actor, d1.dogId, update);
-      expect(res).toEqual("ERROR_UNAUTHORIZED");
+      expect(res).toEqual("ERROR_WRONG_OWNER");
     });
   });
-  it("should return ERROR_MISSING_REPORT when dog does not have an existing report", async () => {
+  it("should return ERROR_SHOULD_UPDATE_FULL_PROFILE when dog does not have an existing report", async () => {
     await withDb(async (dbPool) => {
       const u1 = await insertUser(1, dbPool);
       const d1 = await insertDog(1, u1.userId, dbPool);
       const update = _getSubProfile();
       const actor = getUserActor(dbPool, u1.userId);
       const res = await updateSubProfile(actor, d1.dogId, update);
-      expect(res).toEqual("ERROR_MISSING_REPORT");
+      expect(res).toEqual("ERROR_SHOULD_UPDATE_FULL_PROFILE");
     });
   });
-  it("should return ERROR_MISSING_DOG dog not found", async () => {
+  it("should return ERROR_DOG_NOT_FOUND dog not found", async () => {
     await withDb(async (dbPool) => {
       const u1 = await insertUser(1, dbPool);
       const unknownDogId = "123";
       const update = _getSubProfile();
       const actor = getUserActor(dbPool, u1.userId);
       const res = await updateSubProfile(actor, unknownDogId, update);
-      expect(res).toEqual("ERROR_MISSING_DOG");
+      expect(res).toEqual("ERROR_DOG_NOT_FOUND");
     });
   });
 });


### PR DESCRIPTION
(1) Define a set of standard result/error codes in CODE (bark-code.ts).

(2) Update all cases of ad hoc codes to bark codes.

(3) Standardise naming of server action functions to start with `post...`. So we have a way to differentiate them from internal functions. E.g. postMyAccountDetails() would internally call updateMyAccountDetails().

(4) Use Result<T,E> abstraction when a function needs to return a value. For functions that do not return values (e.g. updates), then they just return OK | other error codes.

(5) A new dbResultQuery alternative that returns `Result<QueryResult<T>, typeof CODE.DB_QUERY_FAILURE>`. The error is returned when there is an exception.
