### PR TITLE
Use toasts to indicate status of saving/adding dog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-select": "^2.0.0",
         "@radix-ui/react-separator": "^1.0.3",
         "@radix-ui/react-slot": "^1.0.2",
+        "@radix-ui/react-toast": "^1.1.5",
         "@types/sprintf-js": "^1.1.4",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
@@ -2312,6 +2313,40 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-toast": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-toast/-/react-toast-1.1.5.tgz",
+      "integrity": "sha512-fRLn227WHIBRSzuRzGJ8W+5YALxofH23y0MlPLddaIpLpCDqdE0NZlS2NRQDRiptfxDeeCjgFIpexB1/zkxDlw==",
+      "dependencies": {
+        "@babel/runtime": "^7.13.10",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-presence": "1.0.1",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
+    "@radix-ui/react-toast": "^1.1.5",
     "@types/sprintf-js": "^1.1.4",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",

--- a/src/app/_lib/toast-delay.ts
+++ b/src/app/_lib/toast-delay.ts
@@ -1,0 +1,6 @@
+/**
+ * A delay amount before showing toasts like Saving..., Adding..., etc. Because
+ * if an action is fast enough (under this delay) we want to go straight to
+ * Saved or Added.
+ */
+export const TOAST_DELAY_MILLIS = 250;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import BarkAuthProvider from "@/components/bark/bark-auth";
 import RootHeader from "@/app/_components/root-header";
 import RootFooter from "@/app/_components/root-footer";
 import clsx from "clsx";
+import { Toaster } from "@/components/ui/toaster";
 
 const siteFont = Montserrat({ subsets: ["latin"] });
 
@@ -30,6 +31,7 @@ export default function RootLayout({
           <RootHeader />
           {children}
           <RootFooter />
+          <Toaster />
         </BarkAuthProvider>
       </body>
     </html>

--- a/src/app/user/(logged-in)/my-pets/add-dog/_components/add-dog-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/add-dog/_components/add-dog-form.tsx
@@ -12,9 +12,11 @@ import {
   DogFormData,
   GeneralDogForm,
 } from "../../_components/general-dog-form";
+import { useToast } from "@/components/ui/use-toast";
 
 export default function AddDogForm(props: { vetOptions: BarkFormOption[] }) {
   const router = useRouter();
+  const {toast} = useToast();
   const { vetOptions } = props;
 
   async function handleValues(
@@ -32,7 +34,17 @@ export default function AddDogForm(props: { vetOptions: BarkFormOption[] }) {
       dogWeightKg,
       ...otherFields,
     };
+    const {dogName} = dogProfile;
+    // TODO: Where to put the 250 value? Let's wait for other use cases to see where makes sense.
+    const delayedToast = setTimeout(() => {
+      toast({
+        title: "Adding...",
+        description: `Profile for ${dogName} is being added.`,
+        variant: "brandInfo",
+      });
+    }, 250);
     const { error } = await postDogProfile(dogProfile);
+    clearTimeout(delayedToast);
     if (error === CODE.ERROR_NOT_LOGGED_IN) {
       router.push(RoutePath.USER_LOGIN_PAGE);
       return Err(error);
@@ -40,6 +52,11 @@ export default function AddDogForm(props: { vetOptions: BarkFormOption[] }) {
     if (error !== undefined) {
       return Err(error);
     }
+    toast({
+      title: "Added!",
+      description: `Profile for ${dogName} has been added.`,
+      variant: "brandSuccess",
+    });
     router.push(RoutePath.USER_MY_PETS);
     return Ok(true);
   }

--- a/src/app/user/(logged-in)/my-pets/add-dog/_components/add-dog-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/add-dog/_components/add-dog-form.tsx
@@ -17,7 +17,7 @@ import { TOAST_DELAY_MILLIS } from "@/app/_lib/toast-delay";
 
 export default function AddDogForm(props: { vetOptions: BarkFormOption[] }) {
   const router = useRouter();
-  const {toast} = useToast();
+  const { toast } = useToast();
   const { vetOptions } = props;
 
   async function handleValues(
@@ -35,7 +35,7 @@ export default function AddDogForm(props: { vetOptions: BarkFormOption[] }) {
       dogWeightKg,
       ...otherFields,
     };
-    const {dogName} = dogProfile;
+    const { dogName } = dogProfile;
     const delayedToast = setTimeout(() => {
       toast({
         title: "Adding...",

--- a/src/app/user/(logged-in)/my-pets/add-dog/_components/add-dog-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/add-dog/_components/add-dog-form.tsx
@@ -13,6 +13,7 @@ import {
   GeneralDogForm,
 } from "../../_components/general-dog-form";
 import { useToast } from "@/components/ui/use-toast";
+import { TOAST_DELAY_MILLIS } from "@/app/_lib/toast-delay";
 
 export default function AddDogForm(props: { vetOptions: BarkFormOption[] }) {
   const router = useRouter();
@@ -35,14 +36,13 @@ export default function AddDogForm(props: { vetOptions: BarkFormOption[] }) {
       ...otherFields,
     };
     const {dogName} = dogProfile;
-    // TODO: Where to put the 250 value? Let's wait for other use cases to see where makes sense.
     const delayedToast = setTimeout(() => {
       toast({
         title: "Adding...",
         description: `Profile for ${dogName} is being added.`,
         variant: "brandInfo",
       });
-    }, 250);
+    }, TOAST_DELAY_MILLIS);
     const { error } = await postDogProfile(dogProfile);
     clearTimeout(delayedToast);
     if (error === CODE.ERROR_NOT_LOGGED_IN) {

--- a/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_actions/post-dog-profile-update.ts
+++ b/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_actions/post-dog-profile-update.ts
@@ -20,7 +20,6 @@ export async function postDogProfileUpdate(args: {
   | typeof CODE.FAILED
 > {
   const { dogId, dogProfile } = args;
-  await new Promise((resolve) => setTimeout(resolve, 2000)); // WIP: remove this false delay
   const actor = await getAuthenticatedUserActor();
   if (actor === null) {
     return CODE.ERROR_NOT_LOGGED_IN;

--- a/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_actions/post-dog-profile-update.ts
+++ b/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_actions/post-dog-profile-update.ts
@@ -20,6 +20,7 @@ export async function postDogProfileUpdate(args: {
   | typeof CODE.FAILED
 > {
   const { dogId, dogProfile } = args;
+  await new Promise((resolve) => setTimeout(resolve, 2000)); // WIP: remove this false delay
   const actor = await getAuthenticatedUserActor();
   if (actor === null) {
     return CODE.ERROR_NOT_LOGGED_IN;

--- a/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_components/edit-dog-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_components/edit-dog-profile-form.tsx
@@ -17,7 +17,6 @@ import {
   GeneralDogForm,
 } from "../../../_components/general-dog-form";
 import { useToast } from "@/components/ui/use-toast";
-import { useState } from "react";
 
 export default function EditDogProfileForm(props: {
   vetOptions: BarkFormOption[];

--- a/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_components/edit-dog-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_components/edit-dog-profile-form.tsx
@@ -17,6 +17,7 @@ import {
   GeneralDogForm,
 } from "../../../_components/general-dog-form";
 import { useToast } from "@/components/ui/use-toast";
+import { TOAST_DELAY_MILLIS } from "@/app/_lib/toast-delay";
 
 export default function EditDogProfileForm(props: {
   vetOptions: BarkFormOption[];
@@ -34,14 +35,13 @@ export default function EditDogProfileForm(props: {
     const dogProfile = toDogProfile(values);
     const { dogName } = dogProfile;
 
-    // TODO: Where to put the 250 value? Let's wait for other use cases to see where makes sense.
     const delayedToast = setTimeout(() => {
       toast({
         title: "Saving...",
         description: `Profile for ${dogName} is being saved.`,
         variant: "brandInfo",
       });
-    }, 250);
+    }, TOAST_DELAY_MILLIS);
     const res = await postDogProfileUpdate({ dogId, dogProfile });
     clearTimeout(delayedToast);
     const t1 = Date.now();

--- a/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_components/edit-dog-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_components/edit-dog-profile-form.tsx
@@ -35,13 +35,14 @@ export default function EditDogProfileForm(props: {
     const dogProfile = toDogProfile(values);
     const { dogName } = dogProfile;
 
+    // TODO: Where to put the 250 value? Let's wait for other use cases to see where makes sense.
     const delayedToast = setTimeout(() => {
       toast({
         title: "Saving...",
         description: `Profile for ${dogName} is being saved.`,
         variant: "brandInfo",
       });
-    }, 100); // WIP: save this constant somewhere.
+    }, 250);
     const res = await postDogProfileUpdate({ dogId, dogProfile });
     clearTimeout(delayedToast);
     const t1 = Date.now();

--- a/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_components/edit-dog-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_components/edit-dog-profile-form.tsx
@@ -16,6 +16,8 @@ import {
   DogFormData,
   GeneralDogForm,
 } from "../../../_components/general-dog-form";
+import { useToast } from "@/components/ui/use-toast";
+import { useState } from "react";
 
 export default function EditDogProfileForm(props: {
   vetOptions: BarkFormOption[];
@@ -23,6 +25,7 @@ export default function EditDogProfileForm(props: {
   existingDogProfile: DogProfile;
 }) {
   const router = useRouter();
+  const { toast } = useToast();
   const { vetOptions, dogId, existingDogProfile } = props;
 
   async function handleValues(
@@ -30,7 +33,17 @@ export default function EditDogProfileForm(props: {
   ): Promise<Result<true, string>> {
     const t0 = Date.now();
     const dogProfile = toDogProfile(values);
+    const { dogName } = dogProfile;
+
+    const delayedToast = setTimeout(() => {
+      toast({
+        title: "Saving...",
+        description: `Profile for ${dogName} is being saved.`,
+        variant: "brandInfo",
+      });
+    }, 100); // WIP: save this constant somewhere.
     const res = await postDogProfileUpdate({ dogId, dogProfile });
+    clearTimeout(delayedToast);
     const t1 = Date.now();
     const postDogProfileUpdateElapsedMs = t1 - t0;
     console.log({ postDogProfileUpdateElapsedMs });
@@ -41,6 +54,11 @@ export default function EditDogProfileForm(props: {
     if (res !== CODE.OK) {
       return Err(res);
     }
+    toast({
+      title: "Saved!",
+      description: `Profile for ${dogName} has been saved.`,
+      variant: "brandSuccess",
+    });
     router.back();
     return Ok(true);
   }

--- a/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_components/edit-dog-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_components/edit-dog-profile-form.tsx
@@ -28,8 +28,12 @@ export default function EditDogProfileForm(props: {
   async function handleValues(
     values: DogFormData,
   ): Promise<Result<true, string>> {
+    const t0 = Date.now();
     const dogProfile = toDogProfile(values);
     const res = await postDogProfileUpdate({ dogId, dogProfile });
+    const t1 = Date.now();
+    const postDogProfileUpdateElapsedMs = t1 - t0;
+    console.log({ postDogProfileUpdateElapsedMs });
     if (res === CODE.ERROR_NOT_LOGGED_IN) {
       router.push(RoutePath.USER_LOGIN_PAGE);
       return Err(res);

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import * as React from "react";
+import * as ToastPrimitives from "@radix-ui/react-toast";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const ToastProvider = ToastPrimitives.Provider;
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName;
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  );
+});
+Toast.displayName = ToastPrimitives.Root.displayName;
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className,
+    )}
+    {...props}
+  />
+));
+ToastAction.displayName = ToastPrimitives.Action.displayName;
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className,
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+));
+ToastClose.displayName = ToastPrimitives.Close.displayName;
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold", className)}
+    {...props}
+  />
+));
+ToastTitle.displayName = ToastPrimitives.Title.displayName;
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+));
+ToastDescription.displayName = ToastPrimitives.Description.displayName;
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>;
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+};

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -32,10 +32,13 @@ const toastVariants = cva(
         default: "border bg-background text-foreground",
         destructive:
           "destructive group border-destructive bg-destructive text-destructive-foreground",
+        brandInfo: "border bg-brand-light text-foreground",
+        brandSuccess: "border bg-brand-light text-foreground",
+        brandError: "border bg-brand text-brand-light",
       },
     },
     defaultVariants: {
-      variant: "default",
+      variant: "brandInfo",
     },
   },
 );

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "@/components/ui/toast";
+import { useToast } from "@/components/ui/use-toast";
+
+export function Toaster() {
+  const { toasts } = useToast();
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && (
+                <ToastDescription>{description}</ToastDescription>
+              )}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        );
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  );
+}

--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -1,0 +1,191 @@
+"use client";
+
+// Inspired by react-hot-toast library
+import * as React from "react";
+
+import type { ToastActionElement, ToastProps } from "@/components/ui/toast";
+
+const TOAST_LIMIT = 1;
+const TOAST_REMOVE_DELAY = 1000000;
+
+type ToasterToast = ToastProps & {
+  id: string;
+  title?: React.ReactNode;
+  description?: React.ReactNode;
+  action?: ToastActionElement;
+};
+
+const actionTypes = {
+  ADD_TOAST: "ADD_TOAST",
+  UPDATE_TOAST: "UPDATE_TOAST",
+  DISMISS_TOAST: "DISMISS_TOAST",
+  REMOVE_TOAST: "REMOVE_TOAST",
+} as const;
+
+let count = 0;
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER;
+  return count.toString();
+}
+
+type ActionType = typeof actionTypes;
+
+type Action =
+  | {
+      type: ActionType["ADD_TOAST"];
+      toast: ToasterToast;
+    }
+  | {
+      type: ActionType["UPDATE_TOAST"];
+      toast: Partial<ToasterToast>;
+    }
+  | {
+      type: ActionType["DISMISS_TOAST"];
+      toastId?: ToasterToast["id"];
+    }
+  | {
+      type: ActionType["REMOVE_TOAST"];
+      toastId?: ToasterToast["id"];
+    };
+
+interface State {
+  toasts: ToasterToast[];
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>();
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return;
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId);
+    dispatch({
+      type: "REMOVE_TOAST",
+      toastId: toastId,
+    });
+  }, TOAST_REMOVE_DELAY);
+
+  toastTimeouts.set(toastId, timeout);
+};
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      };
+
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t,
+        ),
+      };
+
+    case "DISMISS_TOAST": {
+      const { toastId } = action;
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId);
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id);
+        });
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t,
+        ),
+      };
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        };
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      };
+  }
+};
+
+const listeners: Array<(state: State) => void> = [];
+
+let memoryState: State = { toasts: [] };
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action);
+  listeners.forEach((listener) => {
+    listener(memoryState);
+  });
+}
+
+type Toast = Omit<ToasterToast, "id">;
+
+function toast({ ...props }: Toast) {
+  const id = genId();
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: "UPDATE_TOAST",
+      toast: { ...props, id },
+    });
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id });
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss();
+      },
+    },
+  });
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  };
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState);
+
+  React.useEffect(() => {
+    listeners.push(setState);
+    return () => {
+      const index = listeners.indexOf(setState);
+      if (index > -1) {
+        listeners.splice(index, 1);
+      }
+    };
+  }, [state]);
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  };
+}
+
+export { useToast, toast };


### PR DESCRIPTION
(1) Sometimes it can take awhile for data to get into the database. (Another issue!) So, in the frontend we want to indicate when data is "Saving..." and "Saved". In this commit, we use Toasts to accomplish this.

(2) This is experimental. Therefore, only the add-dog and edit-dog save sequences have been instrumented to use toasts. 

(3) Variants have been defined for "brandInfo", "brandSuccess", and "brandError". Not much thought has been put into the styling. This can be revisited in time.
