### PR TITLE
Show in-progress toasts for a fixed duration.

### DIFF
--- a/e2e/_lib/pom/layout/toast-component.ts
+++ b/e2e/_lib/pom/layout/toast-component.ts
@@ -1,0 +1,12 @@
+import { Locator } from "@playwright/test";
+import { PomComponent } from "../core/pom-component";
+
+export class ToastComponent extends PomComponent {
+  locator(): Locator {
+    return this.closeButton().locator("..");
+  }
+
+  closeButton(): Locator {
+    return this.page().getByLabel("Notifications (F8)").getByRole("button");
+  }
+}

--- a/e2e/user/user-can-add-dog.spec.ts
+++ b/e2e/user/user-can-add-dog.spec.ts
@@ -4,6 +4,7 @@ import { getTestBirthday } from "../_lib/e2e-test-utils";
 import { generateTestDogName } from "../_lib/e2e-test-utils";
 import { UserAddDogPage } from "../_lib/pom/pages/user-add-dog-page";
 import { UserMyPetsPage } from "../_lib/pom/pages/user-my-pets-page";
+import { ToastComponent } from "../_lib/pom/layout/toast-component";
 
 test("user can register, login, add dog, and see it in my-pets", async ({
   page,
@@ -31,6 +32,19 @@ test("user can register, login, add dog, and see it in my-pets", async ({
   await pg2.dogEverPregnantOption_NO().click();
   await pg2.dogPreferredVetOption_1().click();
   await pg2.saveButton().click();
+
+  const toast = new ToastComponent(context);
+  await expect(toast.locator()).toBeVisible();
+  await expect(
+    toast.locator().getByText("Adding...", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    toast.locator().getByText("Added!", { exact: true }),
+  ).toBeVisible();
+  await toast.closeButton().click();
+  await expect(
+    toast.locator().getByText("Added!", { exact: true }),
+  ).not.toBeVisible();
 
   // THEN
   const pg3 = new UserMyPetsPage(context);

--- a/e2e/user/user-can-edit-dog.spec.ts
+++ b/e2e/user/user-can-edit-dog.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from "@playwright/test";
 import { registerTestUser } from "../_lib/init/register-test-user";
 import { UserMyPetsPage } from "../_lib/pom/pages/user-my-pets-page";
 import { UserEditDogPage } from "../_lib/pom/pages/user-edit-dog-page";
+import { ToastComponent } from "../_lib/pom/layout/toast-component";
 
 test("user can edit dog profile", async ({ page }) => {
   const { context, dogName, dogBreed, dogBirthday, dogWeightKg } =
@@ -26,6 +27,19 @@ test("user can edit dog profile", async ({ page }) => {
   await pg2.dogBirthdayField().fill("1968-08-28");
   await pg2.dogWeightField().fill("16.827");
   await pg2.saveButton().click();
+
+  const toast = new ToastComponent(context);
+  await expect(toast.locator()).toBeVisible();
+  await expect(
+    toast.locator().getByText("Saving...", { exact: true }),
+  ).toBeVisible();
+  await expect(
+    toast.locator().getByText("Saved!", { exact: true }),
+  ).toBeVisible();
+  await toast.closeButton().click();
+  await expect(
+    toast.locator().getByText("Saved!", { exact: true }),
+  ).not.toBeVisible();
 
   const pg3 = new UserMyPetsPage(context);
   await pg3.checkUrl();

--- a/src/app/_lib/toast-delay.ts
+++ b/src/app/_lib/toast-delay.ts
@@ -1,11 +1,4 @@
 /**
- * A delay amount before showing toasts like Saving..., Adding..., etc. Because
- * if an action is fast enough (under this delay) we want to go straight to
- * Saved or Added.
- */
-export const TOAST_DELAY_MILLIS = 250;
-
-/**
  * The minimum number of milliseconds to display a toast.
  */
 export const MINIMUM_TOAST_MILLIS = 1337;

--- a/src/app/_lib/toast-delay.ts
+++ b/src/app/_lib/toast-delay.ts
@@ -4,3 +4,8 @@
  * Saved or Added.
  */
 export const TOAST_DELAY_MILLIS = 250;
+
+/**
+ * The minimum number of milliseconds to display a toast.
+ */
+export const MINIMUM_TOAST_MILLIS = 1337;

--- a/src/app/user/(logged-in)/my-pets/add-dog/_components/add-dog-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/add-dog/_components/add-dog-form.tsx
@@ -13,7 +13,8 @@ import {
   GeneralDogForm,
 } from "../../_components/general-dog-form";
 import { useToast } from "@/components/ui/use-toast";
-import { TOAST_DELAY_MILLIS } from "@/app/_lib/toast-delay";
+import { MINIMUM_TOAST_MILLIS } from "@/app/_lib/toast-delay";
+import { asyncSleep } from "@/lib/utilities/async-sleep";
 
 export default function AddDogForm(props: { vetOptions: BarkFormOption[] }) {
   const router = useRouter();
@@ -36,15 +37,17 @@ export default function AddDogForm(props: { vetOptions: BarkFormOption[] }) {
       ...otherFields,
     };
     const { dogName } = dogProfile;
-    const delayedToast = setTimeout(() => {
-      toast({
-        title: "Adding...",
-        description: `Profile for ${dogName} is being added.`,
-        variant: "brandInfo",
-      });
-    }, TOAST_DELAY_MILLIS);
-    const { error } = await postDogProfile(dogProfile);
-    clearTimeout(delayedToast);
+    toast({
+      title: "Adding...",
+      description: `Profile for ${dogName} is being added.`,
+      variant: "brandInfo",
+    });
+
+    const [{ error }, _] = await Promise.all([
+      postDogProfile(dogProfile),
+      asyncSleep(MINIMUM_TOAST_MILLIS),
+    ]);
+
     if (error === CODE.ERROR_NOT_LOGGED_IN) {
       router.push(RoutePath.USER_LOGIN_PAGE);
       return Err(error);

--- a/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_components/edit-dog-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/_components/edit-dog-profile-form.tsx
@@ -17,7 +17,8 @@ import {
   GeneralDogForm,
 } from "../../../_components/general-dog-form";
 import { useToast } from "@/components/ui/use-toast";
-import { TOAST_DELAY_MILLIS } from "@/app/_lib/toast-delay";
+import { MINIMUM_TOAST_MILLIS } from "@/app/_lib/toast-delay";
+import { asyncSleep } from "@/lib/utilities/async-sleep";
 
 export default function EditDogProfileForm(props: {
   vetOptions: BarkFormOption[];
@@ -31,22 +32,18 @@ export default function EditDogProfileForm(props: {
   async function handleValues(
     values: DogFormData,
   ): Promise<Result<true, string>> {
-    const t0 = Date.now();
     const dogProfile = toDogProfile(values);
     const { dogName } = dogProfile;
 
-    const delayedToast = setTimeout(() => {
-      toast({
-        title: "Saving...",
-        description: `Profile for ${dogName} is being saved.`,
-        variant: "brandInfo",
-      });
-    }, TOAST_DELAY_MILLIS);
-    const res = await postDogProfileUpdate({ dogId, dogProfile });
-    clearTimeout(delayedToast);
-    const t1 = Date.now();
-    const postDogProfileUpdateElapsedMs = t1 - t0;
-    console.log({ postDogProfileUpdateElapsedMs });
+    toast({
+      title: "Saving...",
+      description: `Profile for ${dogName} is being saved.`,
+      variant: "brandInfo",
+    });
+    const [res, _] = await Promise.all([
+      postDogProfileUpdate({ dogId, dogProfile }),
+      asyncSleep(MINIMUM_TOAST_MILLIS),
+    ]);
     if (res === CODE.ERROR_NOT_LOGGED_IN) {
       router.push(RoutePath.USER_LOGIN_PAGE);
       return Err(res);

--- a/src/lib/utilities/async-sleep.ts
+++ b/src/lib/utilities/async-sleep.ts
@@ -1,0 +1,3 @@
+export function asyncSleep(millis: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, millis));
+}

--- a/src/lib/utilities/async-sleep.ts
+++ b/src/lib/utilities/async-sleep.ts
@@ -1,3 +1,3 @@
 export function asyncSleep(millis: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, millis));
+  return new Promise((resolve) => setTimeout(resolve, millis));
 }


### PR DESCRIPTION
Update add-dog and edit-dog to show the "Adding..." and "Saving..." toasts for at least 1337 milliseconds before showing "Added" and "Saving" toasts.