### PR TITLE
bark-button improvements

### DIFF
--- a/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
+++ b/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
@@ -76,9 +76,11 @@ export default function AccountEditForm({
           ]}
         />
         <div className="mt-6 flex flex-col gap-2 md:flex-row">
-          <BarkButton variant="brand">Save</BarkButton>
+          <BarkButton variant="brand" className="w-full md:w-40">
+            Save
+          </BarkButton>
           <BarkButton
-            className="inline-block h-[60px]"
+            className="inline-block h-[60px] w-full md:w-40"
             variant={"brandInverse"}
             type="button"
             onClick={async () => router.push(RoutePath.USER_MY_ACCOUNT_PAGE)}

--- a/src/app/user/(logged-in)/my-account/page.tsx
+++ b/src/app/user/(logged-in)/my-account/page.tsx
@@ -133,7 +133,7 @@ export default async function Page() {
 
       <div className="flex flex-col gap-3">
         <BarkButton
-          className="w-full md:w-32"
+          className="w-full md:w-40"
           variant="brand"
           href={RoutePath.USER_MY_ACCOUNT_EDIT}
         >

--- a/src/components/bark/bark-button.tsx
+++ b/src/components/bark/bark-button.tsx
@@ -7,12 +7,13 @@ export function BarkButton(props: {
   variant: "brand" | "brandInverse";
   className?: string;
   href?: string;
-  onClick?: () => Promise<void>;
+  onClick?: (() => Promise<void>) | (() => void);
   type?: "button" | "submit" | "reset";
+  disabled?: boolean;
 }) {
-  const { children, variant, className, type, href, onClick } = props;
+  const { children, variant, className, type, disabled, href, onClick } = props;
 
-  if (href !== undefined) {
+  if (href !== undefined && disabled !== true) {
     return (
       <Link
         className={clsx("h-[60px]", className, buttonVariants({ variant }))}
@@ -29,6 +30,7 @@ export function BarkButton(props: {
         variant={variant}
         onClick={onClick}
         type={type}
+        disabled={disabled}
       >
         {children}
       </Button>
@@ -39,6 +41,7 @@ export function BarkButton(props: {
       className={clsx("h-[60px]", className)}
       variant={variant}
       type={type}
+      disabled={disabled}
     >
       {children}
     </Button>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -19,13 +19,12 @@ const buttonVariants = cva(
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
         brandInverse:
-          "text-brand font-bold border-2 border-brand bg-brand-light hover:bg-brand hover:text-white md:w-[160px] shadow-button",
+          "text-brand font-bold border-2 border-brand bg-brand-light hover:opacity-90 active:bg-brand active:text-white shadow-button disabled:opacity-50",
         brand:
-          "text-white font-bold border-2 border-brand bg-brand hover:bg-brand-light hover:text-brand md:w-[160px] shadow-button",
-        brandSelectedChoice:
-          "bg-brand-selected-choice text-primary-foreground md:w-[160px]",
+          "text-white font-bold border-2 border-brand bg-brand hover:opacity-90 active:bg-brand-light active:text-brand shadow-button disabled:opacity-50",
+        brandSelectedChoice: "bg-brand-selected-choice text-primary-foreground",
         brandChoice:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground md:w-[160px]",
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
       },
       size: {
         default: "h-10 px-4 py-2",


### PR DESCRIPTION
(1) Some changes to BarkButton

(1.1) The `onClick` callback type now allows both asynchronous and synchronous functions.

(1.2) Added support for `disabled` buttons.

(1.3) Adjust the styling for `active:` and `hover:` states.

-(a) The earlier behaviour of switching between brand and brandInverse styles is now use to distinguish the `active:` state.

-(b) The `hover:` state is now a light opacity change.

(1.4) `md:w-[160px]` is removed because this makes the button size fixed for `md` screens and bigger—which became an issue when rendering buttons in small spaces on big screens. In general, I think the size of a button is related to the layout of the page and not the style of the button.
