### PR TITLE
Rename UNAUTHORIZED to ERROR_NOT_ALLOWED

### DIFF
--- a/src/app/vet/(logged-in)/appointments/_actions/post-bark-report-data.ts
+++ b/src/app/vet/(logged-in)/appointments/_actions/post-bark-report-data.ts
@@ -17,7 +17,7 @@ export async function postBarkReportData(args: {
     { reportId: string },
     | typeof CODE.ERROR_NOT_LOGGED_IN
     | typeof CODE.ERROR_APPOINTMENT_NOT_FOUND
-    | typeof CODE.UNAUTHORIZED
+    | typeof CODE.ERROR_NOT_ALLOWED
     | typeof CODE.FAILED
   >
 > {

--- a/src/lib/bark/operations/op-submit-report.ts
+++ b/src/lib/bark/operations/op-submit-report.ts
@@ -24,7 +24,7 @@ export async function opSubmitReport(
   Result<
     { reportId: string },
     | typeof CODE.ERROR_APPOINTMENT_NOT_FOUND
-    | typeof CODE.UNAUTHORIZED
+    | typeof CODE.ERROR_NOT_ALLOWED
     | typeof CODE.FAILED
   >
 > {
@@ -45,7 +45,7 @@ export async function opSubmitReport(
       return Err(CODE.ERROR_APPOINTMENT_NOT_FOUND);
     }
     if (ids.vetId !== actorVetId) {
-      return Err(CODE.UNAUTHORIZED);
+      return Err(CODE.ERROR_NOT_ALLOWED);
     }
     const { reportId } = await insertReport(conn, {
       appointmentId,

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -13,11 +13,6 @@ export const CODE = {
   FAILED: "FAILED",
 
   /**
-   * When an actor is not allowed to execute an operation.
-   */
-  UNAUTHORIZED: "UNAUTHORIZED",
-
-  /**
    * When an expected account cannot be found. e.g. when sending OTP.
    */
   ERROR_ACCOUNT_NOT_FOUND: "ERROR_ACCOUNT_NOT_FOUND",
@@ -37,6 +32,11 @@ export const CODE = {
    * type.
    */
   ERROR_NOT_LOGGED_IN: "ERROR_NOT_LOGGED_IN",
+
+  /**
+   * When an actor is not allowed to execute an operation.
+   */
+  UNAUTHORIZED: "UNAUTHORIZED",
 
   /**
    * When a specified user cannot be found.

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -36,7 +36,7 @@ export const CODE = {
   /**
    * When an actor is not allowed to execute an operation.
    */
-  UNAUTHORIZED: "UNAUTHORIZED",
+  ERROR_NOT_ALLOWED: "ERROR_NOT_ALLOWED",
 
   /**
    * When a specified user cannot be found.

--- a/tests/bark/operations/op-submit-report.test.ts
+++ b/tests/bark/operations/op-submit-report.test.ts
@@ -47,7 +47,7 @@ describe("opSubmitReport", () => {
       expect(hasExistingAppointment).toBe(false);
     });
   });
-  it("should return UNAUTHORIZED when the vet does not own the appointment", async () => {
+  it("should return ERROR_NOT_ALLOWED when the vet does not own the appointment", async () => {
     await withBarkContext(async ({ context }) => {
       const a1 = await givenAppointment(context, { idx: 1 });
       const v2 = await givenVet(context, { vetIdx: 2 });
@@ -57,7 +57,7 @@ describe("opSubmitReport", () => {
         reportData,
         actorVetId: v2.vetId,
       });
-      expect(error).toEqual(CODE.UNAUTHORIZED);
+      expect(error).toEqual(CODE.ERROR_NOT_ALLOWED);
       expect(result).toBeUndefined();
     });
   });


### PR DESCRIPTION
(1) Renamed UNAUTHORIZED to ERROR_NOT_ALLOWED to follow the naming style of ERROR_NOT_LOGGED_IN.
