### PR TITLE
Do not show user email to vets

### DIFF
--- a/e2e/_lib/sequences/do-create-appointment.ts
+++ b/e2e/_lib/sequences/do-create-appointment.ts
@@ -10,9 +10,9 @@ import { VetAppointmentListPage } from "../pom/pages/vet-appointment-list-page";
 
 export async function doCreateAppointment(
   context: PomContext,
-): Promise<{ dogName: string; userEmail: string }> {
+): Promise<{ dogName: string }> {
   const page = context.page;
-  const { userEmail, dogName } = await registerTestUser({ page });
+  const { dogName, userName } = await registerTestUser({ page });
   await doLogoutSequence({ context });
   await loginKnownVet({ page });
   const pg1 = new VetSchedulePage(context);
@@ -22,7 +22,7 @@ export async function doCreateAppointment(
   await pg1.dogCard(dogName).locator().click();
   const isMobile = await getIsMobile(context);
   const activityArea = isMobile ? pg1.dogCard(dogName) : pg1.rightSidePane();
-  await expect(activityArea.exactText(userEmail)).toBeVisible();
+  await expect(activityArea.exactText(userName)).toBeVisible();
   await expect(activityArea.scheduleButton()).toBeVisible();
   await activityArea.scheduleButton().click();
 
@@ -34,9 +34,8 @@ export async function doCreateAppointment(
 
   console.log({
     dogName,
-    userEmail,
     _msg: "Created appointment and navigated to appointments list page.",
   });
 
-  return { dogName, userEmail };
+  return { dogName };
 }

--- a/e2e/vet/vet-can-record-appointment-call-outcome.spec.ts
+++ b/e2e/vet/vet-can-record-appointment-call-outcome.spec.ts
@@ -6,7 +6,7 @@ import { VetSchedulePage } from "../_lib/pom/pages/vet-schedule-page";
 import { getIsMobile } from "../_lib/e2e-test-utils";
 
 test("vet can record APPOINTMENT call outcome", async ({ page }) => {
-  const { context, userEmail, dogName } = await registerTestUser({ page });
+  const { context, userName, dogName } = await registerTestUser({ page });
   await doLogoutSequence({ context });
   await loginKnownVet({ page });
   const pg1 = new VetSchedulePage(context);
@@ -17,7 +17,7 @@ test("vet can record APPOINTMENT call outcome", async ({ page }) => {
 
   const isMobile = await getIsMobile(context);
   const activityArea = isMobile ? pg1.dogCard(dogName) : pg1.rightSidePane();
-  await expect(activityArea.exactText(userEmail)).toBeVisible();
+  await expect(activityArea.exactText(userName)).toBeVisible();
   await expect(activityArea.scheduleButton()).toBeVisible();
 
   await activityArea.scheduleButton().click();

--- a/e2e/vet/vet-can-record-declined-call-outcome.spec.ts
+++ b/e2e/vet/vet-can-record-declined-call-outcome.spec.ts
@@ -6,7 +6,7 @@ import { VetSchedulePage } from "../_lib/pom/pages/vet-schedule-page";
 import { getIsMobile } from "../_lib/e2e-test-utils";
 
 test("vet can record DECLINED call outcome", async ({ page }) => {
-  const { context, userEmail, dogName } = await registerTestUser({ page });
+  const { context, userName, dogName } = await registerTestUser({ page });
   await doLogoutSequence({ context });
   await loginKnownVet({ page });
   const pg1 = new VetSchedulePage(context);
@@ -17,7 +17,7 @@ test("vet can record DECLINED call outcome", async ({ page }) => {
 
   const isMobile = await getIsMobile(context);
   const activityArea = isMobile ? pg1.dogCard(dogName) : pg1.rightSidePane();
-  await expect(activityArea.exactText(userEmail)).toBeVisible();
+  await expect(activityArea.exactText(userName)).toBeVisible();
   await expect(activityArea.declineButton()).toBeVisible();
 
   await activityArea.declineButton().click();

--- a/src/app/vet/_lib/components/call-card.tsx
+++ b/src/app/vet/_lib/components/call-card.tsx
@@ -45,6 +45,8 @@ export function CallCard(props: {
       </div>
     );
   }
+
+  // WIP: we omit the userEmail here, but the API is still sending it. We need to omit it from the API responses also.
   const { userName, userPhoneNumber, vetUserLastContactedTime } = result;
 
   // TODO: (Maybe) Add userResidency to OwnerContactDetails. For now, hardcoding

--- a/src/app/vet/_lib/components/call-card.tsx
+++ b/src/app/vet/_lib/components/call-card.tsx
@@ -45,8 +45,7 @@ export function CallCard(props: {
       </div>
     );
   }
-  const { userName, userEmail, userPhoneNumber, vetUserLastContactedTime } =
-    result;
+  const { userName, userPhoneNumber, vetUserLastContactedTime } = result;
 
   // TODO: (Maybe) Add userResidency to OwnerContactDetails. For now, hardcoding
   // is safe because all available dogs have owners residing in Singapore.
@@ -86,7 +85,6 @@ export function CallCard(props: {
         <BarkUserContactDetails
           details={{
             userName,
-            userEmail,
             userPhoneNumber,
             userResidency,
             userLastContactedTime,

--- a/src/app/vet/_lib/components/call-card.tsx
+++ b/src/app/vet/_lib/components/call-card.tsx
@@ -46,7 +46,6 @@ export function CallCard(props: {
     );
   }
 
-  // WIP: we omit the userEmail here, but the API is still sending it. We need to omit it from the API responses also.
   const { userName, userPhoneNumber, vetUserLastContactedTime } = result;
 
   // TODO: (Maybe) Add userResidency to OwnerContactDetails. For now, hardcoding

--- a/src/app/vet/_lib/hooks/use-owner-contact-details.ts
+++ b/src/app/vet/_lib/hooks/use-owner-contact-details.ts
@@ -1,7 +1,10 @@
 import { RoutePath } from "@/lib/route-path";
 import { CODE } from "@/lib/utilities/bark-code";
 import { Err, Ok, Result } from "@/lib/utilities/result";
-import { OwnerContactDetails } from "@/lib/bark/models/owner-contact-details";
+import {
+  OwnerContactDetails,
+  OwnerContactDetailsSchema,
+} from "@/lib/bark/models/owner-contact-details";
 import useSWR from "swr";
 
 type DataType = Result<
@@ -33,13 +36,15 @@ async function fetchOwnerContactDetails(dogIdKey: string): Promise<DataType> {
   const data: { ownerContactDetails: OwnerContactDetails } = await res.json();
   const { ownerContactDetails } = data;
   const { vetUserLastContactedTime, ...others } = ownerContactDetails;
-  return Ok({
-    ...others,
-    vetUserLastContactedTime:
-      vetUserLastContactedTime === null
-        ? null
-        : new Date(vetUserLastContactedTime),
-  });
+  return Ok(
+    OwnerContactDetailsSchema.parse({
+      ...others,
+      vetUserLastContactedTime:
+        vetUserLastContactedTime === null
+          ? null
+          : new Date(vetUserLastContactedTime),
+    }),
+  );
 }
 
 export function useOwnerContactDetails(dogId: string | null): {

--- a/src/app/vet/_lib/hooks/use-owner-contact-details.ts
+++ b/src/app/vet/_lib/hooks/use-owner-contact-details.ts
@@ -1,7 +1,7 @@
 import { RoutePath } from "@/lib/route-path";
 import { CODE } from "@/lib/utilities/bark-code";
 import { Err, Ok, Result } from "@/lib/utilities/result";
-import { OwnerContactDetails } from "@/lib/vet/vet-models";
+import { OwnerContactDetails } from "@/lib/bark/models/owner-contact-details";
 import useSWR from "swr";
 
 type DataType = Result<

--- a/src/app/vet/_lib/models/scheduler-state.ts
+++ b/src/app/vet/_lib/models/scheduler-state.ts
@@ -1,4 +1,5 @@
-import { AvailableDog, OwnerContactDetails } from "@/lib/vet/vet-models";
+import { AvailableDog } from "@/lib/vet/vet-models";
+import { OwnerContactDetails } from "@/lib/bark/models/owner-contact-details";
 import { SchedulerOutcome } from "./scheduler-outcome";
 
 export type SchedulerState = {

--- a/src/components/bark/bark-user-contact-details.tsx
+++ b/src/components/bark/bark-user-contact-details.tsx
@@ -11,7 +11,7 @@ import { NA_TEXT } from "@/app/_lib/constants";
 export function BarkUserContactDetails(props: {
   details: null | {
     userName: string;
-    userEmail: string;
+    userEmail?: string;
     userPhoneNumber: string;
     userResidency: UserResidency;
     userCreationTime?: Date;
@@ -33,6 +33,12 @@ export function BarkUserContactDetails(props: {
     );
   }
 
+  type LineItem = {
+    key: string;
+    icon: React.ReactNode;
+    value: React.ReactNode;
+  };
+
   const {
     userName,
     userEmail,
@@ -41,25 +47,22 @@ export function BarkUserContactDetails(props: {
     userCreationTime,
     userLastContactedTime,
   } = details;
-  const userDetails: {
-    key: string;
-    icon: React.ReactNode;
-    value: React.ReactNode;
-  }[] = [
-    {
-      key: "location",
-      icon: (
-        <Image
-          src={IMG_PATH.LOCATION_MARKER}
-          width={24}
-          height={26}
-          alt="location marker icon"
-          className="h-full w-auto"
-        />
-      ),
-      value: capitalize(userResidency),
-    },
-    {
+  const lineItems: LineItem[] = [];
+  lineItems.push({
+    key: "location",
+    icon: (
+      <Image
+        src={IMG_PATH.LOCATION_MARKER}
+        width={24}
+        height={26}
+        alt="location marker icon"
+        className="h-full w-auto"
+      />
+    ),
+    value: capitalize(userResidency),
+  });
+  if (userEmail !== undefined) {
+    lineItems.push({
       key: "email",
       icon: (
         <Image
@@ -71,21 +74,21 @@ export function BarkUserContactDetails(props: {
         />
       ),
       value: userEmail,
-    },
-    {
-      key: "phone",
-      icon: (
-        <Image
-          src={IMG_PATH.PHONE}
-          width={30}
-          height={30}
-          alt="phone icon icon"
-          className="h-full w-auto"
-        />
-      ),
-      value: userPhoneNumber,
-    },
-  ];
+    });
+  }
+  lineItems.push({
+    key: "phone",
+    icon: (
+      <Image
+        src={IMG_PATH.PHONE}
+        width={30}
+        height={30}
+        alt="phone icon icon"
+        className="h-full w-auto"
+      />
+    ),
+    value: userPhoneNumber,
+  });
 
   const userCreationTimeText =
     userCreationTime === undefined
@@ -117,7 +120,7 @@ export function BarkUserContactDetails(props: {
         </p>
       </div>
       <div className="flex flex-col gap-3">
-        {userDetails.map((detail) => {
+        {lineItems.map((detail) => {
           const { key, icon, value } = detail;
           return (
             <div key={key} className="flex items-center gap-2">

--- a/src/lib/bark/models/owner-contact-details.ts
+++ b/src/lib/bark/models/owner-contact-details.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 export const OwnerContactDetailsSchema = z.object({
   dogId: z.string(),
   userName: z.string(),
-  userEmail: z.string().email(),
   userPhoneNumber: z.string(),
 
   /**

--- a/src/lib/bark/models/owner-contact-details.ts
+++ b/src/lib/bark/models/owner-contact-details.ts
@@ -1,11 +1,15 @@
-export type OwnerContactDetails = {
-  dogId: string;
-  userName: string;
-  userEmail: string;
-  userPhoneNumber: string;
+import { z } from "zod";
+
+export const OwnerContactDetailsSchema = z.object({
+  dogId: z.string(),
+  userName: z.string(),
+  userEmail: z.string().email(),
+  userPhoneNumber: z.string(),
 
   /**
    * The last time the vet contacted the user.
    */
-  vetUserLastContactedTime: Date | null;
-};
+  vetUserLastContactedTime: z.date().nullable(),
+});
+
+export type OwnerContactDetails = z.infer<typeof OwnerContactDetailsSchema>;

--- a/src/lib/bark/models/owner-contact-details.ts
+++ b/src/lib/bark/models/owner-contact-details.ts
@@ -1,0 +1,11 @@
+export type OwnerContactDetails = {
+  dogId: string;
+  userName: string;
+  userEmail: string;
+  userPhoneNumber: string;
+
+  /**
+   * The last time the vet contacted the user.
+   */
+  vetUserLastContactedTime: Date | null;
+};

--- a/src/lib/vet/actions/get-owner-contact-details.ts
+++ b/src/lib/vet/actions/get-owner-contact-details.ts
@@ -1,6 +1,6 @@
 import { Err, Ok, Result } from "@/lib/utilities/result";
 import { VetActor } from "../vet-actor";
-import { OwnerContactDetails } from "../vet-models";
+import { OwnerContactDetails } from "@/lib/bark/models/owner-contact-details";
 import { dbQuery } from "@/lib/data/db-utils";
 import { CODE } from "@/lib/utilities/bark-code";
 

--- a/src/lib/vet/actions/get-owner-contact-details.ts
+++ b/src/lib/vet/actions/get-owner-contact-details.ts
@@ -1,6 +1,9 @@
 import { Err, Ok, Result } from "@/lib/utilities/result";
 import { VetActor } from "../vet-actor";
-import { OwnerContactDetails } from "@/lib/bark/models/owner-contact-details";
+import {
+  OwnerContactDetails,
+  OwnerContactDetailsSchema,
+} from "@/lib/bark/models/owner-contact-details";
 import { dbQuery } from "@/lib/data/db-utils";
 import { CODE } from "@/lib/utilities/bark-code";
 
@@ -31,7 +34,7 @@ export async function getOwnerContactDetails(
     return Err(CODE.ERROR_NOT_PREFERRED_VET);
   }
   const res = await toOwnerContactDetails(ctx, row);
-  return Ok(res);
+  return Ok(OwnerContactDetailsSchema.parse(res));
 }
 
 type Context = {
@@ -90,12 +93,11 @@ async function toOwnerContactDetails(
   const { actor, dogId } = ctx;
   const { userMapper } = actor.getParams();
   const { isPreferredVet, userEncryptedPii, ...otherFields } = row;
-  const { userName, userEmail, userPhoneNumber } =
+  const { userName, userPhoneNumber } =
     await userMapper.mapUserEncryptedPiiToUserPii({ userEncryptedPii });
   return {
     dogId,
     userName,
-    userEmail,
     userPhoneNumber,
     ...otherFields,
   };

--- a/src/lib/vet/vet-models.ts
+++ b/src/lib/vet/vet-models.ts
@@ -11,15 +11,3 @@ export type AvailableDog = {
   dogEverReceivedTransfusion: YesNoUnknown;
   dogEverPregnant: YesNoUnknown;
 };
-
-export type OwnerContactDetails = {
-  dogId: string;
-  userName: string;
-  userEmail: string;
-  userPhoneNumber: string;
-
-  /**
-   * The last time the vet contacted the user.
-   */
-  vetUserLastContactedTime: Date | null;
-};

--- a/tests/vet/get-owner-contact-details.test.ts
+++ b/tests/vet/get-owner-contact-details.test.ts
@@ -12,7 +12,10 @@ import {
   dbDeleteDogVetPreference,
   dbInsertDogVetPreference,
 } from "@/lib/data/db-dogs";
-import { OwnerContactDetails } from "@/lib/bark/models/owner-contact-details";
+import {
+  OwnerContactDetails,
+  OwnerContactDetailsSchema,
+} from "@/lib/bark/models/owner-contact-details";
 import { getOwnerContactDetails } from "@/lib/vet/actions/get-owner-contact-details";
 import { CALL_OUTCOME } from "@/lib/data/db-enums";
 import { CODE } from "@/lib/utilities/bark-code";
@@ -134,13 +137,12 @@ async function insertOwner(
   const { dogId } = await insertDog(idx, userId, dbPool);
   const { preferredVetId } = args;
   await dbInsertDogVetPreference(dbPool, dogId, preferredVetId);
-  const { userName, userEmail, userPhoneNumber } = await userPii(idx);
-  const ownerContactDetails: OwnerContactDetails = {
+  const { userName, userPhoneNumber } = await userPii(idx);
+  const ownerContactDetails = OwnerContactDetailsSchema.parse({
     dogId,
     userName,
-    userEmail,
     userPhoneNumber,
     vetUserLastContactedTime: null,
-  };
+  });
   return { userId, dogId, ownerContactDetails };
 }

--- a/tests/vet/get-owner-contact-details.test.ts
+++ b/tests/vet/get-owner-contact-details.test.ts
@@ -12,7 +12,7 @@ import {
   dbDeleteDogVetPreference,
   dbInsertDogVetPreference,
 } from "@/lib/data/db-dogs";
-import { OwnerContactDetails } from "@/lib/vet/vet-models";
+import { OwnerContactDetails } from "@/lib/bark/models/owner-contact-details";
 import { getOwnerContactDetails } from "@/lib/vet/actions/get-owner-contact-details";
 import { CALL_OUTCOME } from "@/lib/data/db-enums";
 import { CODE } from "@/lib/utilities/bark-code";


### PR DESCRIPTION
(1) User email is not useful for a call-list and it is also a login credential. Thus, in this commit, user emails are removed from the vet interfaces.

(2) Changes

(2.1) The BarkUserContactDetails component is updated to optionally accept user email. Email is provided in My Account, but not when a vet is viewing Owner Contact Details.

(2.2) The API for fetching owner contact details no longer provides user email.
