### PR TITLE
Revise the general report form

### DIFF
--- a/e2e/_lib/pom/pages/vet-general-report-form.ts
+++ b/e2e/_lib/pom/pages/vet-general-report-form.ts
@@ -60,6 +60,10 @@ export abstract class VetGeneralReportForm extends PomDynamicPage {
     return this.page().getByLabel("Eligible", { exact: true });
   }
 
+  ineligibilityReasonTextArea(): Locator {
+    return this.page().getByLabel("Please indicate if there are reasons");
+  }
+
   dogEligibility_TEMPORARILY_INELIGIBLE(): Locator {
     return this.page().getByLabel("Temporarily Ineligible", { exact: true });
   }
@@ -68,11 +72,9 @@ export abstract class VetGeneralReportForm extends PomDynamicPage {
     return this.page().getByLabel("Permanantly Ineligible", { exact: true });
   }
 
-  ineligibilityReasonTextArea(): Locator {
-    return this.page().getByLabel("Please indicate if there are reasons");
-  }
-
   ineligibilityExpiryDateField(): Locator {
-    return this.page().getByLabel("Please indicate a date after");
+    return this.page().getByLabel(
+      "For temporary ineligibility, please indicate",
+    );
   }
 }

--- a/e2e/_lib/pom/pages/vet-general-report-form.ts
+++ b/e2e/_lib/pom/pages/vet-general-report-form.ts
@@ -56,10 +56,6 @@ export abstract class VetGeneralReportForm extends PomDynamicPage {
     return this.page().getByLabel("No", { exact: true });
   }
 
-  dogEligibility_ELIGIBLE(): Locator {
-    return this.page().getByLabel("Eligible", { exact: true });
-  }
-
   ineligibilityReasonTextArea(): Locator {
     return this.page().getByLabel("Please indicate if there are reasons");
   }

--- a/e2e/_lib/pom/pages/vet-general-report-form.ts
+++ b/e2e/_lib/pom/pages/vet-general-report-form.ts
@@ -2,8 +2,8 @@ import { PomDynamicPage } from "../core/pom-dynamic-page";
 import { Locator } from "@playwright/test";
 
 export abstract class VetGeneralReportForm extends PomDynamicPage {
-  visitTimeField(): Locator {
-    return this.page().getByLabel("Visit Time");
+  visitDateField(): Locator {
+    return this.page().getByLabel("Visit Date");
   }
 
   dogWeightField(): Locator {

--- a/e2e/_lib/pom/pages/vet-general-report-form.ts
+++ b/e2e/_lib/pom/pages/vet-general-report-form.ts
@@ -69,7 +69,7 @@ export abstract class VetGeneralReportForm extends PomDynamicPage {
   }
 
   ineligibilityReasonTextArea(): Locator {
-    return this.page().getByLabel("Please indicate a reason (if");
+    return this.page().getByLabel("Please indicate if there are reasons");
   }
 
   ineligibilityExpiryDateField(): Locator {

--- a/e2e/vet/vet-can-edit-report.spec.ts
+++ b/e2e/vet/vet-can-edit-report.spec.ts
@@ -54,7 +54,6 @@ async function givenSubmittedReport(context: PomContext): Promise<{
   await pgSubmit.dogHeartwormOption_NEGATIVE().click();
   await pgSubmit.dogDea1Point1_POSITIVE().click();
   await pgSubmit.dogDidDonateBlood_YES().click();
-  await pgSubmit.dogEligibility_ELIGIBLE().click();
   await pgSubmit.submitButton().click();
 
   await pgList.checkUrl();

--- a/e2e/vet/vet-can-edit-report.spec.ts
+++ b/e2e/vet/vet-can-edit-report.spec.ts
@@ -47,7 +47,7 @@ async function givenSubmittedReport(context: PomContext): Promise<{
   await pgList.appointmentCard({ dogName }).submitReportButton().click();
 
   await pgSubmit.checkUrl();
-  await pgSubmit.visitTimeField().fill("6 May 2024, 13:30");
+  await pgSubmit.visitDateField().fill("6 May 2024");
   await pgSubmit.dogWeightField().fill("27.89");
   await pgSubmit.dogBcsSelector().click();
   await pgSubmit.dogBcsOption8().click();

--- a/e2e/vet/vet-can-submit-report.spec.ts
+++ b/e2e/vet/vet-can-submit-report.spec.ts
@@ -16,8 +16,8 @@ test("vet can submit report", async ({ page }) => {
 
   const pg2 = new VetAppointmentSubmitReportPage(context);
   await pg2.checkUrl();
-  await pg2.visitTimeField().fill("6 May 2024, 13:30");
-  await pg2.dogWeightField().fill("27.89");
+  await pg2.visitDateField().fill("11 May 2024");
+  await pg2.dogWeightField().fill("28.61");
   await pg2.dogBcsSelector().click();
   await pg2.dogBcsOption8().click();
   await pg2.dogHeartwormOption_NEGATIVE().click();

--- a/e2e/vet/vet-can-submit-report.spec.ts
+++ b/e2e/vet/vet-can-submit-report.spec.ts
@@ -23,7 +23,6 @@ test("vet can submit report", async ({ page }) => {
   await pg2.dogHeartwormOption_NEGATIVE().click();
   await pg2.dogDea1Point1_POSITIVE().click();
   await pg2.dogDidDonateBlood_YES().click();
-  await pg2.dogEligibility_ELIGIBLE().click();
   await pg2.submitButton().click();
 
   const pg3 = new VetAppointmentListPage(context);

--- a/e2e/vet/vet-can-view-report.spec.ts
+++ b/e2e/vet/vet-can-view-report.spec.ts
@@ -24,7 +24,7 @@ test("vet can view report", async ({ page }) => {
     .submitReportButton()
     .click();
   await pgSubmit.checkUrl();
-  await pgSubmit.visitTimeField().fill("13 Jan 2021, 15:55");
+  await pgSubmit.visitDateField().fill("13 Jan 2021");
   await pgSubmit.dogWeightField().fill("42.5");
   await pgSubmit.dogBcsSelector().click();
   await pgSubmit.dogBcsOption5().click();

--- a/e2e/vet/vet-can-view-report.spec.ts
+++ b/e2e/vet/vet-can-view-report.spec.ts
@@ -31,8 +31,8 @@ test("vet can view report", async ({ page }) => {
   await pgSubmit.dogHeartwormOption_POSITIVE().click();
   await pgSubmit.dogDea1Point1_POSITIVE().click();
   await pgSubmit.dogDidDonateBlood_NO().click();
-  await pgSubmit.dogEligibility_TEMPORARILY_INELIGIBLE().click();
   await pgSubmit.ineligibilityReasonTextArea().fill("The dog is too fat.");
+  await pgSubmit.dogEligibility_TEMPORARILY_INELIGIBLE().click();
   await pgSubmit.ineligibilityExpiryDateField().fill("1 Feb 2022");
   await pgSubmit.submitButton().click();
   await pgAppointmentList.checkUrl();

--- a/e2e/vet/vet-can-view-report.spec.ts
+++ b/e2e/vet/vet-can-view-report.spec.ts
@@ -47,7 +47,7 @@ test("vet can view report", async ({ page }) => {
   // Check values
   await pgView.checkUrl();
   await expect(
-    pgView.field("Visit Time").getByText("13 Jan 2021 3:55PM", { exact: true }),
+    pgView.field("Visit Date").getByText("13 Jan 2021", { exact: true }),
   ).toBeVisible();
   await expect(
     pgView.field("Ineligible Until").getByText("1 Feb 2022", { exact: true }),

--- a/src/app/vet/_lib/components/general-report-form.tsx
+++ b/src/app/vet/_lib/components/general-report-form.tsx
@@ -32,7 +32,6 @@ import { useForm } from "react-hook-form";
 import { z } from "zod";
 import { Result } from "@/lib/utilities/result";
 import {
-  SGT_ISO8601,
   SGT_UI_DATE,
   SGT_UI_DATE_TIME,
   formatDateTime,
@@ -105,6 +104,7 @@ const DEFAULT_REPORT_FORM_DATA = {
   visitTime: "",
   dogWeightKg: "",
   ineligibilityReason: "",
+  ineligibilityStatus: REPORTED_INELIGIBILITY.NIL,
   ineligibilityExpiryTime: "",
 };
 
@@ -122,6 +122,13 @@ export function GeneralReportForm(props: {
         ? DEFAULT_REPORT_FORM_DATA
         : toReportFormData(reportData),
   });
+  // WIP: validate reported ineligibility across form fields.
+
+  const currentValues = form.watch();
+  const hasReason = currentValues.ineligibilityReason !== "";
+  const isTemporary =
+    currentValues.ineligibilityStatus ===
+    REPORTED_INELIGIBILITY.TEMPORARILY_INELIGIBLE;
 
   const onSubmit = async (values: ReportFormData) => {
     const reportData = toBarkReportData(values);
@@ -222,32 +229,31 @@ export function GeneralReportForm(props: {
         name="ineligibilityReason"
         label="Please indicate if there are reasons why this dog might be ineligible for blood donation"
       />
-      <BarkFormRadioGroup
-        form={form}
-        name="ineligibilityStatus"
-        label="Please indicate if dog is eligible for blood donation"
-        // placeholder="Select eligibility"
-        options={[
-          {
-            value: REPORTED_INELIGIBILITY.NIL,
-            label: `Eligible`,
-          },
-          {
-            value: REPORTED_INELIGIBILITY.TEMPORARILY_INELIGIBLE,
-            label: `Temporarily Ineligible`,
-          },
-          {
-            value: REPORTED_INELIGIBILITY.PERMANENTLY_INELIGIBLE,
-            label: `Permanently Ineligible`,
-          },
-        ]}
-      />
-      <BarkFormInput
-        form={form}
-        name="ineligibilityExpiryTime"
-        label="Please indicate a date after which dog might be eligible again"
-        type="text"
-      />
+      {hasReason && (
+        <BarkFormRadioGroup
+          form={form}
+          name="ineligibilityStatus"
+          label="Is this reason for ineligibility temporary or permanent?"
+          options={[
+            {
+              value: REPORTED_INELIGIBILITY.TEMPORARILY_INELIGIBLE,
+              label: `Temporarily Ineligible`,
+            },
+            {
+              value: REPORTED_INELIGIBILITY.PERMANENTLY_INELIGIBLE,
+              label: `Permanently Ineligible`,
+            },
+          ]}
+        />
+      )}
+      {hasReason && isTemporary && (
+        <BarkFormInput
+          form={form}
+          name="ineligibilityExpiryTime"
+          label="For temporary ineligibility, please indicate a date after which dog might be eligible again"
+          type="text"
+        />
+      )}
       <BarkFormError form={form} />
       <div className="mt-6 flex w-full flex-col gap-3 md:flex-row">
         <BarkButton className="w-full md:w-40" variant="brand" type="submit">

--- a/src/app/vet/_lib/components/general-report-form.tsx
+++ b/src/app/vet/_lib/components/general-report-form.tsx
@@ -140,6 +140,7 @@ export function GeneralReportForm(props: {
 
   const onCancel = handleCancel;
 
+  // WIP: Split form into sections: (a) Visit Outcomes; (b) Observations; and (c) Reported Ineligibility
   return (
     <BarkForm form={form} onSubmit={onSubmit}>
       <BarkFormInput

--- a/src/app/vet/_lib/components/general-report-form.tsx
+++ b/src/app/vet/_lib/components/general-report-form.tsx
@@ -139,7 +139,7 @@ function toReportFormData(reportData: BarkReportData): ReportFormData {
     ...otherFields
   } = reportData;
   const formData: ReportFormData = {
-    visitTime: formatDateTime(visitTime, SGT_UI_DATE_TIME),
+    visitTime: formatDateTime(visitTime, SGT_UI_DATE),
     dogWeightKg: `${dogWeightKg}`,
     dogBodyConditioningScore: `${dogBodyConditioningScore}`,
     dogDidDonateBlood: dogDidDonateBlood ? "YES" : "NO",

--- a/src/app/vet/_lib/components/general-report-form.tsx
+++ b/src/app/vet/_lib/components/general-report-form.tsx
@@ -39,7 +39,7 @@ import {
 import { Separator } from "@/components/ui/separator";
 
 const ReportFormDataSchema = z.object({
-  visitTime: DateTimeField.Schema,
+  visitTime: DateField.getSchema(),
   dogWeightKg: DogWeightKgField.Schema,
   dogBodyConditioningScore: BodyConditioningScoreField.Schema,
   dogHeartworm: PosNegNilSchema,
@@ -50,6 +50,8 @@ const ReportFormDataSchema = z.object({
   dogDidDonateBlood: z.enum([YES_NO_UNKNOWN.YES, YES_NO_UNKNOWN.NO]),
 });
 
+// WIP: visit date cannot be in the future
+// WIP: expiry date must be after visit date.
 // Refine schema to do cross-field validations
 const schemaWithRefinements = ReportFormDataSchema.refine(
   (data) => {
@@ -97,7 +99,7 @@ function toBarkReportData(formData: ReportFormData): BarkReportData {
     ...otherFields
   } = formData;
   const values: BarkReportData = {
-    visitTime: DateTimeField.parse(visitTime),
+    visitTime: DateField.parse(visitTime),
     dogWeightKg: DogWeightKgField.parse(dogWeightKg)!,
     dogBodyConditioningScore: BodyConditioningScoreField.parse(
       dogBodyConditioningScore,
@@ -203,9 +205,9 @@ export function GeneralReportForm(props: {
           <BarkFormInput
             form={form}
             name="visitTime"
-            label="Visit Time"
+            label="Visit Date"
             type="text"
-            description="Please provide the visit time, e.g. 16 Apr 2021 4:30pm"
+            description="Please provide the visit date, e.g. 16 Apr 2021"
           />
           <BarkFormRadioGroup
             form={form}
@@ -325,6 +327,7 @@ export function GeneralReportForm(props: {
               name="ineligibilityExpiryTime"
               label="For temporary ineligibility, please indicate a date after which dog might be eligible again"
               type="text"
+              description="Please provide a date, e.g. 16 Apr 2021"
             />
           )}
         </div>

--- a/src/app/vet/_lib/components/general-report-form.tsx
+++ b/src/app/vet/_lib/components/general-report-form.tsx
@@ -217,6 +217,11 @@ export function GeneralReportForm(props: {
           },
         ]}
       />
+      <BarkFormTextArea
+        form={form}
+        name="ineligibilityReason"
+        label="Please indicate if there are reasons why this dog might be ineligible for blood donation"
+      />
       <BarkFormRadioGroup
         form={form}
         name="ineligibilityStatus"
@@ -236,11 +241,6 @@ export function GeneralReportForm(props: {
             label: `Permanently Ineligible`,
           },
         ]}
-      />
-      <BarkFormTextArea
-        form={form}
-        name="ineligibilityReason"
-        label="Please indicate a reason (if ineligible)"
       />
       <BarkFormInput
         form={form}

--- a/src/app/vet/_lib/components/general-report-form.tsx
+++ b/src/app/vet/_lib/components/general-report-form.tsx
@@ -36,6 +36,7 @@ import {
   SGT_UI_DATE_TIME,
   formatDateTime,
 } from "@/lib/utilities/bark-time";
+import { Separator } from "@/components/ui/separator";
 
 const ReportFormDataSchema = z.object({
   visitTime: DateTimeField.Schema,
@@ -189,133 +190,157 @@ export function GeneralReportForm(props: {
 
   const onCancel = handleCancel;
 
-  // WIP: Split form into sections: (a) Visit Outcomes; (b) Observations; and (c) Reported Ineligibility
   return (
     <BarkForm form={form} onSubmit={onSubmit}>
-      <BarkFormInput
-        form={form}
-        name="visitTime"
-        label="Visit Time"
-        type="text"
-        description="Please provide the visit time, e.g. 16 Apr 2021 4:30pm"
-      />
-      <BarkFormInput
-        form={form}
-        name="dogWeightKg"
-        label="Dog's Weight (KG)"
-        type="text"
-      />
-      <BarkFormSelect
-        form={form}
-        name="dogBodyConditioningScore"
-        label="Dog's Body Conditioning Score (BCS)"
-        placeholder="Select BCS"
-        options={BodyConditioningScoreField.values.map((value: number) => {
-          const option: BarkFormOption = {
-            value: `${value}`,
-            label: `${value}`,
-          };
-          return option;
-        })}
-        description="Body conditioning score is a value between 1 and 9"
-      />
-      <BarkFormRadioGroup
-        form={form}
-        name="dogHeartworm"
-        label="Heartworm Test Result"
-        options={[
-          {
-            value: POS_NEG_NIL.POSITIVE,
-            label: "Tested positive for heartworm",
-          },
-          {
-            value: POS_NEG_NIL.NEGATIVE,
-            label: "Tested negative for heartworm",
-          },
-          {
-            value: POS_NEG_NIL.NIL,
-            label: "Did not test",
-          },
-        ]}
-        description="Please indicate the result of heartworm test, if any"
-      />
-      <BarkFormRadioGroup
-        form={form}
-        name="dogDea1Point1"
-        label="Blood Test Result"
-        options={[
-          {
-            value: POS_NEG_NIL.POSITIVE,
-            label: "DEA 1.1 Positive",
-          },
-          {
-            value: POS_NEG_NIL.NEGATIVE,
-            label: "DEA 1.1 Negative",
-          },
-          {
-            value: POS_NEG_NIL.NIL,
-            label: "Did not test",
-          },
-        ]}
-        description="Please indicate the result of blood test, if any"
-      />
-      <BarkFormRadioGroup
-        form={form}
-        name="dogDidDonateBlood"
-        label="Please indicate if dog donated blood"
-        options={[
-          {
-            value: YES_NO_UNKNOWN.YES,
-            label: `Yes`,
-          },
-          {
-            value: YES_NO_UNKNOWN.NO,
-            label: `No`,
-          },
-        ]}
-      />
-      <BarkFormTextArea
-        form={form}
-        name="ineligibilityReason"
-        label="Please indicate if there are reasons why this dog might be ineligible for blood donation"
-      />
-      {hasReason && (
-        <BarkFormRadioGroup
-          form={form}
-          name="ineligibilityStatus"
-          label="Is this reason for ineligibility temporary or permanent?"
-          options={[
-            {
-              value: REPORTED_INELIGIBILITY.TEMPORARILY_INELIGIBLE,
-              label: `Temporarily Ineligible`,
-            },
-            {
-              value: REPORTED_INELIGIBILITY.PERMANENTLY_INELIGIBLE,
-              label: `Permanently Ineligible`,
-            },
-          ]}
-        />
-      )}
-      {hasReason && isTemporary && (
-        <BarkFormInput
-          form={form}
-          name="ineligibilityExpiryTime"
-          label="For temporary ineligibility, please indicate a date after which dog might be eligible again"
-          type="text"
-        />
-      )}
-      <BarkFormError form={form} />
-      <div className="mt-6 flex w-full flex-col gap-3 md:flex-row">
-        <BarkButton className="w-full md:w-40" variant="brand" type="submit">
-          {purpose === "SUBMIT" ? "Submit Report" : "Save Changes"}
-        </BarkButton>
-        <BarkButton
-          className="w-full md:w-40"
-          variant="brandInverse"
-          onClick={onCancel}
-        >
-          Cancel
-        </BarkButton>
+      <div className="flex flex-col gap-3">
+        <div className="x-card x-card-bg prose">
+          <h2 className="x-card-title">Visit & Outcomes</h2>
+          <p>
+            This section is about capturing details of the visit and the
+            outcomes.
+          </p>
+          <Separator />
+          <BarkFormInput
+            form={form}
+            name="visitTime"
+            label="Visit Time"
+            type="text"
+            description="Please provide the visit time, e.g. 16 Apr 2021 4:30pm"
+          />
+          <BarkFormRadioGroup
+            form={form}
+            name="dogDidDonateBlood"
+            label="Please indicate if dog donated blood"
+            options={[
+              {
+                value: YES_NO_UNKNOWN.YES,
+                label: `Yes`,
+              },
+              {
+                value: YES_NO_UNKNOWN.NO,
+                label: `No`,
+              },
+            ]}
+          />
+        </div>
+        <div className="x-card x-card-bg prose">
+          <h2 className="x-card-title">Observations</h2>
+          <p>
+            This section captures medical observations made during the visit.
+          </p>
+          <Separator />
+          <BarkFormInput
+            form={form}
+            name="dogWeightKg"
+            label="Dog's Weight (KG)"
+            type="text"
+          />
+          <BarkFormSelect
+            form={form}
+            name="dogBodyConditioningScore"
+            label="Dog's Body Conditioning Score (BCS)"
+            placeholder="Select BCS"
+            options={BodyConditioningScoreField.values.map((value: number) => {
+              const option: BarkFormOption = {
+                value: `${value}`,
+                label: `${value}`,
+              };
+              return option;
+            })}
+            description="Body conditioning score is a value between 1 and 9"
+          />
+          <BarkFormRadioGroup
+            form={form}
+            name="dogHeartworm"
+            label="Heartworm Test Result"
+            options={[
+              {
+                value: POS_NEG_NIL.POSITIVE,
+                label: "Tested positive for heartworm",
+              },
+              {
+                value: POS_NEG_NIL.NEGATIVE,
+                label: "Tested negative for heartworm",
+              },
+              {
+                value: POS_NEG_NIL.NIL,
+                label: "Did not test",
+              },
+            ]}
+            description="Please indicate the result of heartworm test, if any"
+          />
+          <BarkFormRadioGroup
+            form={form}
+            name="dogDea1Point1"
+            label="Blood Test Result"
+            options={[
+              {
+                value: POS_NEG_NIL.POSITIVE,
+                label: "DEA 1.1 Positive",
+              },
+              {
+                value: POS_NEG_NIL.NEGATIVE,
+                label: "DEA 1.1 Negative",
+              },
+              {
+                value: POS_NEG_NIL.NIL,
+                label: "Did not test",
+              },
+            ]}
+            description="Please indicate the result of blood test, if any"
+          />
+        </div>
+        <div className="x-card x-card-bg prose">
+          <h2 className="x-card-title">Ineligibility</h2>
+          <p>
+            This section captures reasons for why the dog might be ineligible
+            for blood donation.
+          </p>
+          <Separator />
+          <BarkFormTextArea
+            form={form}
+            name="ineligibilityReason"
+            label="Please indicate if there are reasons why this dog might be ineligible for blood donation. (Leave blank if there are none.)"
+          />
+          {hasReason && (
+            <BarkFormRadioGroup
+              form={form}
+              name="ineligibilityStatus"
+              label="Is this reason for ineligibility temporary or permanent?"
+              options={[
+                {
+                  value: REPORTED_INELIGIBILITY.TEMPORARILY_INELIGIBLE,
+                  label: `Temporarily Ineligible`,
+                },
+                {
+                  value: REPORTED_INELIGIBILITY.PERMANENTLY_INELIGIBLE,
+                  label: `Permanently Ineligible`,
+                },
+              ]}
+            />
+          )}
+          {hasReason && isTemporary && (
+            <BarkFormInput
+              form={form}
+              name="ineligibilityExpiryTime"
+              label="For temporary ineligibility, please indicate a date after which dog might be eligible again"
+              type="text"
+            />
+          )}
+        </div>
+        <BarkFormError form={form} />
+        <div className="mt-6 flex w-full flex-col gap-3 md:flex-row">
+          <BarkButton className="w-full md:w-40" variant="brand" type="submit">
+            {purpose === "SUBMIT" ? "Submit Report" : "Save Changes"}
+          </BarkButton>
+          <BarkButton
+            className="w-full md:w-40"
+            variant="brandInverse"
+            onClick={onCancel}
+          >
+            Cancel
+          </BarkButton>
+        </div>
       </div>
     </BarkForm>
   );

--- a/src/app/vet/_lib/components/report-card.tsx
+++ b/src/app/vet/_lib/components/report-card.tsx
@@ -14,7 +14,7 @@ import {
   ReportedIneligibility,
 } from "@/lib/data/db-enums";
 import { RoutePath } from "@/lib/route-path";
-import { SGT_UI_DATE_TIME, formatDateTime } from "@/lib/utilities/bark-time";
+import { SGT_UI_DATE, formatDateTime } from "@/lib/utilities/bark-time";
 import clsx from "clsx";
 import { capitalize } from "lodash";
 import { Droplets, Worm } from "lucide-react";
@@ -53,7 +53,7 @@ export function ReportCard(props: { report: BarkReport }) {
         {getDonated(dogDidDonateBlood)}
       </div>
       {getReportedIneligibility(ineligibilityStatus)}
-      <p>Visit Time: {formatDateTime(visitTime, SGT_UI_DATE_TIME)}</p>
+      <p>Visited on {formatDateTime(visitTime, SGT_UI_DATE)}</p>
       <p className="flex-1">
         <span className="font-semibold text-slate-700">{dogName}</span> is a{" "}
         <span className="font-semibold text-slate-500">

--- a/src/app/vet/_lib/components/report-view.tsx
+++ b/src/app/vet/_lib/components/report-view.tsx
@@ -38,7 +38,7 @@ export function ReportView(props: { report: BarkReport }) {
   };
 
   const fields: Field[] = [
-    { label: "Visit Time", value: formatDateTime(visitTime, SGT_UI_DATE_TIME) },
+    { label: "Visit Date", value: formatDateTime(visitTime, SGT_UI_DATE) },
     { label: "Owner Name", value: ownerName },
     { label: "Dog Name", value: dogName },
     { label: "Dog Gender", value: capitalize(dogGender) },

--- a/src/components/bark/bark-form.tsx
+++ b/src/components/bark/bark-form.tsx
@@ -230,8 +230,9 @@ export function BarkFormRadioGroup(props: {
   options: BarkFormOption[];
   description?: string;
   layout?: "button" | "radio";
+  disabled?: boolean;
 }) {
-  const { layout, form, name, label, options, description } = props;
+  const { layout, form, name, label, options, description, disabled } = props;
   return (
     <FormField
       control={form.control}
@@ -265,6 +266,7 @@ export function BarkFormRadioGroup(props: {
                 onValueChange={field.onChange}
                 defaultValue={field.value}
                 className="flex flex-col"
+                disabled={disabled}
               >
                 {options.map((option) => (
                   <FormItem


### PR DESCRIPTION
(1) This revises the form inputs in the General Report Form for Reported Ineligibility. Previously, the form framed the questions as one about Eligibility. This misses the point of Reported Ineligibility, which is to ask for additional reasons why a dog might be ineligible.

(2) This also include the following additional improvements.

(2.1) Improved validation for Reported Ineligibility. —(a) Ask for reason, then status, and then expiry date. —(b) Smartly check for reason before using status. E.g. if the reason is empty and the status is temporarily ineligible, the status recorded should still be NIL.

(2.2) Visit Time is changed to Visit Date.

(2.3) Improved cross-field validations. E.g. ineligibility expiry date is required when temporarily ineligible, and only when temporarily ineligible. Another example is checking that visit date is not in the future. The full list can be found in the `schemaWithRefinements` object.

(2.4) Improved presentation. The form is now split into three sections: (i) Visit & Outcomes; (ii) Observations; and (iii) Ineligibility.
