### PR TITLE
Fix postMyAccountDetails

### DIFF
--- a/src/app/user/(logged-in)/my-account/edit/_actions/post-my-account-details.ts
+++ b/src/app/user/(logged-in)/my-account/edit/_actions/post-my-account-details.ts
@@ -1,19 +1,19 @@
 "use server";
 
 import { getAuthenticatedUserActor } from "@/lib/auth";
-import { RoutePath } from "@/lib/route-path";
 import { updateMyAccountDetails } from "@/lib/user/actions/update-my-account-details";
 import { MyAccountDetailsUpdate } from "@/lib/user/user-models";
 import { CODE } from "@/lib/utilities/bark-code";
 import { revalidatePath } from "next/cache";
-import { redirect } from "next/navigation";
 
 export async function postMyAccountDetails(
   request: MyAccountDetailsUpdate,
-): Promise<typeof CODE.OK | typeof CODE.FAILED> {
+): Promise<
+  typeof CODE.OK | typeof CODE.ERROR_NOT_LOGGED_IN | typeof CODE.FAILED
+> {
   const actor = await getAuthenticatedUserActor();
   if (actor === null) {
-    redirect(RoutePath.USER_LOGIN_PAGE);
+    return CODE.ERROR_NOT_LOGGED_IN;
   }
 
   const response = await updateMyAccountDetails(actor, request);

--- a/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
+++ b/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
@@ -50,6 +50,10 @@ export default function AccountEditForm({
     const request: MyAccountDetailsUpdate = values;
 
     const response = await postMyAccountDetails(request);
+    if (response === CODE.ERROR_NOT_LOGGED_IN) {
+      router.push(RoutePath.USER_LOGIN_PAGE);
+      return;
+    }
     if (response === CODE.OK) {
       router.push(RoutePath.USER_MY_ACCOUNT_PAGE);
       return;


### PR DESCRIPTION
Server actions are POST handlers. Therefore, postMyAccountDetails should not redirect, but instead return a ERROR_NOT_LOGGED_IN code. The client component calling the server action should be the one doing the redirect.
