### PR TITLE
Add support for editing sub profiles

### DIFF
--- a/e2e/_lib/pom/pages/user-edit-sub-profile-page.ts
+++ b/e2e/_lib/pom/pages/user-edit-sub-profile-page.ts
@@ -1,0 +1,66 @@
+import { RoutePath } from "@/lib/route-path";
+import { PomDynamicPage } from "../core/pom-dynamic-page";
+import { Locator } from "@playwright/test";
+import { YES_NO, YesNo } from "@/lib/bark/enums/yes-no";
+
+export class UserEditSubProfilePage extends PomDynamicPage {
+  urlRegex(): RegExp {
+    return RoutePath.USER_EDIT_DOG_REGEX;
+  }
+
+  dogNameField(): Locator {
+    return this.page().getByLabel("Name");
+  }
+
+  dogWeightField(): Locator {
+    return this.page().getByLabel("Weight");
+  }
+
+  dogEverReceivedTransfusionOption(val: YesNo): Locator {
+    const div = this.page()
+      .getByText("Ever Received Blood Transfusion", { exact: true })
+      .locator("..");
+    if (val === YES_NO.YES) {
+      return div.getByLabel("Yes", { exact: true });
+    }
+    if (val === YES_NO.NO) {
+      return div.getByLabel("No", { exact: true });
+    }
+    throw Error(`Invalid option val=${val}`);
+  }
+
+  dogEverPregnantOption(val: YesNo): Locator {
+    const div = this.page()
+      .getByText("Ever Pregnant", { exact: true })
+      .locator("..");
+    if (val === YES_NO.YES) {
+      return div.getByLabel("Yes", { exact: true });
+    }
+    if (val === YES_NO.NO) {
+      return div.getByLabel("No", { exact: true });
+    }
+    throw Error(`Invalid option val=${val}`);
+  }
+
+  dogPreferredVetOption_1(): Locator {
+    return this.page()
+      .getByText("Preferred Donation Point", { exact: true })
+      .locator("..")
+      .getByLabel("Vet Clinic 1", { exact: true });
+  }
+
+  dogPreferredVetOption_2(): Locator {
+    return this.page()
+      .getByText("Preferred Donation Point", { exact: true })
+      .locator("..")
+      .getByLabel("Vet Clinic 2", { exact: true });
+  }
+
+  saveButton(): Locator {
+    return this.page().getByRole("button", { name: "Save" });
+  }
+
+  cancelButton(): Locator {
+    return this.page().getByRole("button", { name: "Cancel" });
+  }
+}

--- a/e2e/_lib/pom/pages/user-edit-sub-profile-page.ts
+++ b/e2e/_lib/pom/pages/user-edit-sub-profile-page.ts
@@ -8,6 +8,13 @@ export class UserEditSubProfilePage extends PomDynamicPage {
     return RoutePath.USER_EDIT_DOG_REGEX;
   }
 
+  /**
+   * @returns Any locator that indicates the form for sub-profile was loaded.
+   */
+  evidenceThisIsTheSubProfileForm(): Locator {
+    return this.page().getByText("Note that after the first");
+  }
+
   dogNameField(): Locator {
     return this.page().getByLabel("Name");
   }

--- a/e2e/_lib/pom/pages/user-view-dog-page.ts
+++ b/e2e/_lib/pom/pages/user-view-dog-page.ts
@@ -8,6 +8,10 @@ export class UserViewDogPage extends PomDynamicPage {
     return RoutePath.USER_VIEW_DOG_REGEX;
   }
 
+  dogNameHeader(name: string): Locator {
+    return this.page().getByRole("heading", { name, exact: true });
+  }
+
   dogBreedItem(): Locator {
     return this.profileItem("Breed");
   }

--- a/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
+++ b/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
@@ -84,7 +84,7 @@ test("user can view report and edit sub-profile", async ({
   await pgEdit.checkUrl();
   await expect(pgEdit.evidenceThisIsTheSubProfileForm()).toBeVisible();
   await pgEdit.dogNameField().fill(newName);
-  await pgEdit.dogEverReceivedTransfusionOption(YES_NO.YES);
+  await pgEdit.dogEverReceivedTransfusionOption(YES_NO.YES).click();
   await pgEdit.dogWeightField().fill(newWeight);
   await pgEdit.saveButton().click();
 
@@ -92,5 +92,7 @@ test("user can view report and edit sub-profile", async ({
   await pgViewDog.checkUrl();
   await expect(pgViewDog.dogNameHeader(newName)).toBeVisible();
   await expect(pgViewDog.dogWeightItem()).toContainText(newWeight);
-  await expect(pgViewDog.dogEverReceivedTransfusionItem()).toContainText("Yes");
+  await expect(pgViewDog.dogEverReceivedTransfusionItem()).toContainText(
+    "Yes, ever received blood transfusion",
+  );
 });

--- a/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
+++ b/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
@@ -17,8 +17,15 @@ import {
   formatDateTime,
   parseCommonDate,
 } from "@/lib/utilities/bark-time";
+import { UserEditSubProfilePage } from "../_lib/pom/pages/user-edit-sub-profile-page";
+import { YES_NO } from "@/lib/bark/enums/yes-no";
 
-test("user can view report", async ({ page }) => {
+test("user can view report and edit sub-profile", async ({
+  page,
+}, testInfo) => {
+  // This test can take some time...
+  testInfo.setTimeout(60000);
+
   const reportedDogWeightKg = "111";
   const yesterday = new Date(Date.now() - MILLIS_PER_DAY);
   const visitTimeText = formatDateTime(yesterday, SGT_UI_DATE);
@@ -51,7 +58,7 @@ test("user can view report", async ({ page }) => {
 
   const pgPets = new UserMyPetsPage(context);
   const pgViewDog = new UserViewDogPage(context);
-  const pgEditDog = new UserEditDogPage(context);
+  const pgEdit = new UserEditSubProfilePage(context);
   const pgViewReport = new UserViewReportPage(context);
 
   // Verify that dog's weight is the registration dog weight, because
@@ -66,4 +73,24 @@ test("user can view report", async ({ page }) => {
   await pgViewReport.checkUrl();
   await expect(pgViewReport.dogWeightItem()).toContainText(reportedDogWeightKg);
   await expect(pgViewReport.dogBreedItem()).toContainText(dogBreed);
+
+  // Edit sub-profile. When a dog has a report, the View Dog edit button should
+  // take us to the form for editing sub-profile.
+  const newName = "Molly Briggs";
+  const newWeight = "333";
+  await pgViewReport.backButton().click();
+  await pgViewDog.checkUrl();
+  await pgViewDog.editButton().click();
+  await pgEdit.checkUrl();
+  await expect(pgEdit.evidenceThisIsTheSubProfileForm()).toBeVisible();
+  await pgEdit.dogNameField().fill(newName);
+  await pgEdit.dogEverReceivedTransfusionOption(YES_NO.YES);
+  await pgEdit.dogWeightField().fill(newWeight);
+  await pgEdit.saveButton().click();
+
+  // Verify the edits, we should be in the view dog page again.
+  await pgViewDog.checkUrl();
+  // await expect(pgViewDog.dogName()).toContainText(newName);
+  await expect(pgViewDog.dogWeightItem()).toContainText(newWeight);
+  await expect(pgViewDog.dogEverReceivedTransfusionItem()).toContainText("Yes");
 });

--- a/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
+++ b/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
@@ -90,7 +90,7 @@ test("user can view report and edit sub-profile", async ({
 
   // Verify the edits, we should be in the view dog page again.
   await pgViewDog.checkUrl();
-  // await expect(pgViewDog.dogName()).toContainText(newName);
+  await expect(pgViewDog.dogNameHeader(newName)).toBeVisible();
   await expect(pgViewDog.dogWeightItem()).toContainText(newWeight);
   await expect(pgViewDog.dogEverReceivedTransfusionItem()).toContainText("Yes");
 });

--- a/src/app/_lib/get-vet-form-options.ts
+++ b/src/app/_lib/get-vet-form-options.ts
@@ -2,7 +2,7 @@ import { BarkFormOption } from "@/components/bark/bark-form";
 import { dbQuery } from "@/lib/data/db-utils";
 import { Pool } from "pg";
 
-// TODO: Move this into lib/bark/operations
+// TODO: Move this into lib/bark/operations as opFetchVetProfiles returning VetProfile[]
 export async function getVetFormOptions(
   dbPool: Pool,
 ): Promise<BarkFormOption[]> {

--- a/src/app/user/(logged-in)/my-pets/_lib/actions/post-sub-profile-update.ts
+++ b/src/app/user/(logged-in)/my-pets/_lib/actions/post-sub-profile-update.ts
@@ -1,0 +1,33 @@
+"use server";
+
+import { getAuthenticatedUserActor } from "@/lib/auth";
+import { SubProfile } from "@/lib/bark/models/sub-profile";
+import { RoutePath } from "@/lib/route-path";
+import { updateSubProfile } from "@/lib/user/actions/update-sub-profile";
+import { CODE } from "@/lib/utilities/bark-code";
+import { revalidatePath } from "next/cache";
+
+export async function postSubProfileUpdate(args: {
+  dogId: string;
+  subProfile: SubProfile;
+}): Promise<
+  | typeof CODE.OK
+  | typeof CODE.DB_QUERY_FAILURE
+  | typeof CODE.ERROR_WRONG_OWNER
+  | typeof CODE.ERROR_DOG_NOT_FOUND
+  | typeof CODE.ERROR_SHOULD_UPDATE_FULL_PROFILE
+  | typeof CODE.FAILED
+  | typeof CODE.ERROR_NOT_LOGGED_IN
+> {
+  const actor = await getAuthenticatedUserActor();
+  if (actor === null) {
+    return CODE.ERROR_NOT_LOGGED_IN;
+  }
+  const { dogId, subProfile } = args;
+  const error = await updateSubProfile(actor, dogId, subProfile);
+  if (error !== CODE.OK) {
+    return error;
+  }
+  revalidatePath(RoutePath.USER_MY_PETS, "layout");
+  return CODE.OK;
+}

--- a/src/app/user/(logged-in)/my-pets/_lib/components/edit-dog-profile-form-controller.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/edit-dog-profile-form-controller.tsx
@@ -12,7 +12,7 @@ import { useToast } from "@/components/ui/use-toast";
 import { MINIMUM_TOAST_MILLIS } from "@/app/_lib/toast-delay";
 import { asyncSleep } from "@/lib/utilities/async-sleep";
 
-export default function EditDogProfileFormController(props: {
+export function EditDogProfileFormController(props: {
   vetOptions: BarkFormOption[];
   dogId: string;
   existingDogProfile: DogProfile;

--- a/src/app/user/(logged-in)/my-pets/_lib/components/general-dog-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/general-dog-form.tsx
@@ -8,7 +8,6 @@ import {
   BarkFormParagraph,
   BarkFormRadioGroup,
 } from "@/components/bark/bark-form";
-import { isValidWeightKg } from "@/lib/utilities/bark-utils";
 import { DOG_ANTIGEN_PRESENCE } from "@/lib/bark/enums/dog-antigen-presence";
 import { YES_NO_UNKNOWN } from "@/lib/bark/enums/yes-no-unknown";
 import { DOG_GENDER, SPECIFIED_DOG_GENDER } from "@/lib/bark/enums/dog-gender";

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
@@ -1,0 +1,5 @@
+import { SubProfileForm } from "./sub-profile-form";
+
+export function SubProfileFormController() {
+  return <SubProfileForm />;
+}

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { BarkFormOption } from "@/components/bark/bark-form";
 import { SubProfileForm } from "./sub-profile-form";
 import { DogProfile } from "@/lib/bark/models/dog-profile";

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
@@ -1,11 +1,36 @@
 import { BarkFormOption } from "@/components/bark/bark-form";
 import { SubProfileForm } from "./sub-profile-form";
 import { DogProfile } from "@/lib/bark/models/dog-profile";
+import { SubProfile } from "@/lib/bark/models/sub-profile";
+import { Ok, Result } from "@/lib/utilities/result";
 
 export function SubProfileFormController(props: {
   vetOptions: BarkFormOption[];
   dogId: string;
   existingDogProfile: DogProfile;
 }) {
-  return <SubProfileForm />;
+  const { vetOptions, dogId, existingDogProfile } = props;
+
+  const onCancel = async () => {
+    console.debug({ _msg: "onCancel was triggered" });
+  };
+
+  const onSubmit = async (
+    subProfile: SubProfile,
+  ): Promise<Result<true, string>> => {
+    console.debug({
+      _msg: "onSubmit was triggered",
+      subProfile,
+    });
+    return Ok(true);
+  };
+
+  return (
+    <SubProfileForm
+      vetOptions={vetOptions}
+      dogProfile={existingDogProfile}
+      handleCancel={onCancel}
+      handleSubmit={onSubmit}
+    />
+  );
 }

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
@@ -4,7 +4,10 @@ import { BarkFormOption } from "@/components/bark/bark-form";
 import { SubProfileForm } from "./sub-profile-form";
 import { DogProfile } from "@/lib/bark/models/dog-profile";
 import { SubProfile } from "@/lib/bark/models/sub-profile";
-import { Ok, Result } from "@/lib/utilities/result";
+import { Err, Ok, Result } from "@/lib/utilities/result";
+import { useRouter } from "next/navigation";
+import { RoutePath } from "@/lib/route-path";
+import { CODE } from "@/lib/utilities/bark-code";
 
 export function SubProfileFormController(props: {
   vetOptions: BarkFormOption[];
@@ -13,19 +16,20 @@ export function SubProfileFormController(props: {
   subProfile: SubProfile;
 }) {
   const { vetOptions, dogId, dogProfile, subProfile } = props;
+  const router = useRouter();
 
   const onCancel = async () => {
-    console.debug({ _msg: "onCancel was triggered" });
+    router.push(RoutePath.USER_VIEW_DOG(dogId));
   };
 
   const onSubmit = async (
     subProfile: SubProfile,
   ): Promise<Result<true, string>> => {
-    console.debug({
+    console.log({
       _msg: "onSubmit was triggered",
       subProfile,
     });
-    return Ok(true);
+    return Err(CODE.ERROR_NOT_IMPLEMENTED);
   };
 
   return (

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
@@ -1,5 +1,11 @@
+import { BarkFormOption } from "@/components/bark/bark-form";
 import { SubProfileForm } from "./sub-profile-form";
+import { DogProfile } from "@/lib/bark/models/dog-profile";
 
-export function SubProfileFormController() {
+export function SubProfileFormController(props: {
+  vetOptions: BarkFormOption[];
+  dogId: string;
+  existingDogProfile: DogProfile;
+}) {
   return <SubProfileForm />;
 }

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
@@ -7,9 +7,10 @@ import { Ok, Result } from "@/lib/utilities/result";
 export function SubProfileFormController(props: {
   vetOptions: BarkFormOption[];
   dogId: string;
-  existingDogProfile: DogProfile;
+  dogProfile: DogProfile;
+  subProfile: SubProfile;
 }) {
-  const { vetOptions, dogId, existingDogProfile } = props;
+  const { vetOptions, dogId, dogProfile, subProfile } = props;
 
   const onCancel = async () => {
     console.debug({ _msg: "onCancel was triggered" });
@@ -28,7 +29,8 @@ export function SubProfileFormController(props: {
   return (
     <SubProfileForm
       vetOptions={vetOptions}
-      dogProfile={existingDogProfile}
+      dogProfile={dogProfile}
+      subProfile={subProfile}
       handleCancel={onCancel}
       handleSubmit={onSubmit}
     />

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form-controller.tsx
@@ -8,6 +8,7 @@ import { Err, Ok, Result } from "@/lib/utilities/result";
 import { useRouter } from "next/navigation";
 import { RoutePath } from "@/lib/route-path";
 import { CODE } from "@/lib/utilities/bark-code";
+import { postSubProfileUpdate } from "../actions/post-sub-profile-update";
 
 export function SubProfileFormController(props: {
   vetOptions: BarkFormOption[];
@@ -29,7 +30,16 @@ export function SubProfileFormController(props: {
       _msg: "onSubmit was triggered",
       subProfile,
     });
-    return Err(CODE.ERROR_NOT_IMPLEMENTED);
+    const err = await postSubProfileUpdate({ dogId, subProfile });
+    if (err === CODE.ERROR_NOT_LOGGED_IN) {
+      router.push(RoutePath.USER_LOGIN_PAGE);
+      return Err(err);
+    }
+    if (err !== CODE.OK) {
+      return Err(err);
+    }
+    router.push(RoutePath.USER_VIEW_DOG(dogId));
+    return Ok(true);
   };
 
   return (

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
@@ -1,7 +1,22 @@
+import { OptionalDogWeightKgField } from "@/app/_lib/field-schemas/optional-dog-weight-kg-field";
+import { RequiredDogWeightKgField } from "@/app/_lib/field-schemas/required-dog-weight-kg-field";
 import { BarkFormOption } from "@/components/bark/bark-form";
+import { YesNoSchema } from "@/lib/bark/enums/yes-no";
+import { YES_NO_UNKNOWN } from "@/lib/bark/enums/yes-no-unknown";
 import { DogProfile } from "@/lib/bark/models/dog-profile";
-import { SubProfile } from "@/lib/bark/models/sub-profile";
+import { SubProfile, SubProfileSchema } from "@/lib/bark/models/sub-profile";
 import { Result } from "@/lib/utilities/result";
+import { z } from "zod";
+
+const FormDataSchema = z.object({
+  dogName: z.string(),
+  dogWeightKg: RequiredDogWeightKgField.new().schema(),
+  dogEverPregnant: YesNoSchema,
+  dogEverReceivedTransfusion: YesNoSchema,
+  dogPreferredVetId: z.string(),
+});
+
+type FormData = z.infer<typeof FormDataSchema>;
 
 export function SubProfileForm(props: {
   vetOptions: BarkFormOption[];
@@ -10,4 +25,26 @@ export function SubProfileForm(props: {
   handleCancel: () => Promise<void>;
 }) {
   return <div>SubProfileForm</div>;
+}
+
+function _toFormData(dogProfile: DogProfile): FormData {
+  const out: FormData = {
+    dogName: dogProfile.dogName,
+    dogWeightKg:
+      dogProfile.dogWeightKg === null ? "" : dogProfile.dogWeightKg.toString(),
+    dogEverPregnant:
+      dogProfile.dogEverPregnant === YES_NO_UNKNOWN.UNKNOWN
+        ? YES_NO_UNKNOWN.NO
+        : dogProfile.dogEverPregnant,
+    dogEverReceivedTransfusion:
+      dogProfile.dogEverReceivedTransfusion === YES_NO_UNKNOWN.UNKNOWN
+        ? YES_NO_UNKNOWN.NO
+        : dogProfile.dogEverReceivedTransfusion,
+    dogPreferredVetId: dogProfile.dogPreferredVetId,
+  };
+  return FormDataSchema.parse(out);
+}
+
+function _toSubProfile(formData: FormData): SubProfile {
+  return SubProfileSchema.parse({});
 }

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
@@ -1,11 +1,13 @@
-import { OptionalDogWeightKgField } from "@/app/_lib/field-schemas/optional-dog-weight-kg-field";
+"use client";
+
 import { RequiredDogWeightKgField } from "@/app/_lib/field-schemas/required-dog-weight-kg-field";
 import { BarkFormOption } from "@/components/bark/bark-form";
 import { YesNoSchema } from "@/lib/bark/enums/yes-no";
-import { YES_NO_UNKNOWN } from "@/lib/bark/enums/yes-no-unknown";
 import { DogProfile } from "@/lib/bark/models/dog-profile";
 import { SubProfile, SubProfileSchema } from "@/lib/bark/models/sub-profile";
 import { Result } from "@/lib/utilities/result";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 const FormDataSchema = z.object({
@@ -27,8 +29,13 @@ export function SubProfileForm(props: {
 }) {
   const { vetOptions, dogProfile, subProfile, handleSubmit, handleCancel } =
     props;
-  const formData = _toFormData(subProfile);
-  const outData = _toSubProfile(formData);
+  const form = useForm<FormData>({
+    resolver: zodResolver(FormDataSchema),
+    defaultValues: _toFormData(subProfile),
+  });
+
+  const debugFormDefaultValues = _toFormData(subProfile);
+  const debugOutputSubProfile = _toSubProfile(debugFormDefaultValues);
   return (
     <div>
       <h1>Sub Profile Form</h1>
@@ -37,8 +44,8 @@ export function SubProfileForm(props: {
           {
             dogProfile,
             subProfile,
-            formData,
-            outData,
+            debugFormDefaultValues,
+            debugOutputSubProfile,
           },
           null,
           2,

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
@@ -1,0 +1,5 @@
+export function SubProfileForm() {
+  return (
+    <div>SubProfileForm</div>
+  );
+}

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
@@ -1,5 +1,3 @@
 export function SubProfileForm() {
-  return (
-    <div>SubProfileForm</div>
-  );
+  return <div>SubProfileForm</div>;
 }

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
@@ -1,8 +1,17 @@
 "use client";
 
 import { RequiredDogWeightKgField } from "@/app/_lib/field-schemas/required-dog-weight-kg-field";
-import { BarkFormOption } from "@/components/bark/bark-form";
+import { formatBirthday, formatBloodType } from "@/app/_lib/formatters";
+import { BarkButton } from "@/components/bark/bark-button";
+import {
+  BarkForm,
+  BarkFormError,
+  BarkFormInput,
+  BarkFormOption,
+  BarkFormRadioGroup,
+} from "@/components/bark/bark-form";
 import { YesNoSchema } from "@/lib/bark/enums/yes-no";
+import { YES_NO_UNKNOWN } from "@/lib/bark/enums/yes-no-unknown";
 import { DogProfile } from "@/lib/bark/models/dog-profile";
 import { SubProfile, SubProfileSchema } from "@/lib/bark/models/sub-profile";
 import { Result } from "@/lib/utilities/result";
@@ -34,23 +43,96 @@ export function SubProfileForm(props: {
     defaultValues: _toFormData(subProfile),
   });
 
-  const debugFormDefaultValues = _toFormData(subProfile);
-  const debugOutputSubProfile = _toSubProfile(debugFormDefaultValues);
+  const onSubmit = async (formData: FormData) => {
+    const subProfile = _toSubProfile(formData);
+    const { error } = await handleSubmit(subProfile);
+    if (error !== undefined) {
+      form.setError("root", { message: error });
+    }
+  };
+
   return (
     <div>
-      <h1>Sub Profile Form</h1>
-      <pre>
-        {JSON.stringify(
-          {
-            dogProfile,
-            subProfile,
-            debugFormDefaultValues,
-            debugOutputSubProfile,
-          },
-          null,
-          2,
-        )}
-      </pre>
+      <div className="prose">
+        <h1>Edit Dog</h1>
+        <p>
+          Note that after the first report from a vet has been received, the
+          following cannot be edited:
+        </p>
+        <ul>
+          <li>Breed: {dogProfile.dogBreed}</li>
+          <li>Gender: {dogProfile.dogGender}</li>
+          <li>Birthday: {formatBirthday(dogProfile.dogBirthday)}</li>
+          <li>Blood Type: {formatBloodType(dogProfile.dogDea1Point1)}</li>
+        </ul>
+      </div>
+      <BarkForm form={form} onSubmit={onSubmit}>
+        <BarkFormInput
+          form={form}
+          name="dogName"
+          label="Dog Name"
+          type="text"
+        />
+        <BarkFormInput
+          form={form}
+          name="dogWeightKg"
+          label="Dog Weight (KG)"
+          type="text"
+        />
+        <BarkFormRadioGroup
+          form={form}
+          label="Ever Received Blood Transfusion"
+          name="dogEverReceivedTransfusion"
+          layout="radio"
+          options={[
+            {
+              label: "Yes",
+              value: YES_NO_UNKNOWN.YES,
+            },
+            {
+              label: "No",
+              value: YES_NO_UNKNOWN.NO,
+            },
+          ]}
+        />
+        <BarkFormRadioGroup
+          form={form}
+          label="Ever Pregnant"
+          name="dogEverPregnant"
+          layout="radio"
+          options={[
+            {
+              label: "Yes",
+              value: YES_NO_UNKNOWN.YES,
+            },
+            {
+              label: "No",
+              value: YES_NO_UNKNOWN.NO,
+            },
+          ]}
+        />
+        <BarkFormRadioGroup
+          form={form}
+          label="Preferred Donation Point"
+          name="dogPreferredVetId"
+          options={vetOptions}
+        />
+        <BarkFormError form={form} />
+
+        <div className="mt-6 flex flex-col gap-3 md:flex-row-reverse md:justify-end">
+          <BarkButton
+            className="w-full md:w-40"
+            variant="brandInverse"
+            type="button"
+            onClick={handleCancel}
+          >
+            Cancel
+          </BarkButton>
+          <BarkButton className="w-full md:w-40" variant="brand" type="submit">
+            Save
+          </BarkButton>
+        </div>
+      </BarkForm>
     </div>
   );
 }

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
@@ -46,5 +46,10 @@ function _toFormData(dogProfile: DogProfile): FormData {
 }
 
 function _toSubProfile(formData: FormData): SubProfile {
-  return SubProfileSchema.parse({});
+  const { dogWeightKg, ...fields } = formData;
+  const out: SubProfile = {
+    dogWeightKg: RequiredDogWeightKgField.new().parse(dogWeightKg),
+    ...fields,
+  };
+  return SubProfileSchema.parse(out);
 }

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
@@ -1,3 +1,13 @@
-export function SubProfileForm() {
+import { BarkFormOption } from "@/components/bark/bark-form";
+import { DogProfile } from "@/lib/bark/models/dog-profile";
+import { SubProfile } from "@/lib/bark/models/sub-profile";
+import { Result } from "@/lib/utilities/result";
+
+export function SubProfileForm(props: {
+  vetOptions: BarkFormOption[];
+  dogProfile: DogProfile;
+  handleSubmit: (subProfile: SubProfile) => Promise<Result<true, string>>;
+  handleCancel: () => Promise<void>;
+}) {
   return <div>SubProfileForm</div>;
 }

--- a/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/sub-profile-form.tsx
@@ -21,26 +21,38 @@ type FormData = z.infer<typeof FormDataSchema>;
 export function SubProfileForm(props: {
   vetOptions: BarkFormOption[];
   dogProfile: DogProfile;
+  subProfile: SubProfile;
   handleSubmit: (subProfile: SubProfile) => Promise<Result<true, string>>;
   handleCancel: () => Promise<void>;
 }) {
-  return <div>SubProfileForm</div>;
+  const { vetOptions, dogProfile, subProfile, handleSubmit, handleCancel } =
+    props;
+  const formData = _toFormData(subProfile);
+  const outData = _toSubProfile(formData);
+  return (
+    <div>
+      <h1>Sub Profile Form</h1>
+      <pre>
+        {JSON.stringify(
+          {
+            dogProfile,
+            subProfile,
+            formData,
+            outData,
+          },
+          null,
+          2,
+        )}
+      </pre>
+    </div>
+  );
 }
 
-function _toFormData(dogProfile: DogProfile): FormData {
+function _toFormData(subProfile: SubProfile): FormData {
+  const { dogWeightKg, ...fields } = subProfile;
   const out: FormData = {
-    dogName: dogProfile.dogName,
-    dogWeightKg:
-      dogProfile.dogWeightKg === null ? "" : dogProfile.dogWeightKg.toString(),
-    dogEverPregnant:
-      dogProfile.dogEverPregnant === YES_NO_UNKNOWN.UNKNOWN
-        ? YES_NO_UNKNOWN.NO
-        : dogProfile.dogEverPregnant,
-    dogEverReceivedTransfusion:
-      dogProfile.dogEverReceivedTransfusion === YES_NO_UNKNOWN.UNKNOWN
-        ? YES_NO_UNKNOWN.NO
-        : dogProfile.dogEverReceivedTransfusion,
-    dogPreferredVetId: dogProfile.dogPreferredVetId,
+    dogWeightKg: RequiredDogWeightKgField.new().format(dogWeightKg),
+    ...fields,
   };
   return FormDataSchema.parse(out);
 }

--- a/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/page.tsx
+++ b/src/app/user/(logged-in)/my-pets/edit-dog/[dogId]/page.tsx
@@ -36,7 +36,11 @@ export default async function Page(props: { params: { dogId: string } }) {
   if (reportCount.numReports > 0) {
     return (
       <div className="m-3">
-        <SubProfileFormController />
+        <SubProfileFormController
+          vetOptions={vetOptions}
+          dogId={dogId}
+          existingDogProfile={dogProfile}
+        />
       </div>
     );
   }

--- a/src/lib/bark/mappers/to-sub-profile.ts
+++ b/src/lib/bark/mappers/to-sub-profile.ts
@@ -1,0 +1,19 @@
+import { DogProfile } from "../models/dog-profile";
+import { SubProfile, SubProfileSchema } from "../models/sub-profile";
+
+export function toSubProfile(dogProfile: DogProfile): SubProfile {
+  const {
+    dogName,
+    dogWeightKg,
+    dogEverPregnant,
+    dogEverReceivedTransfusion,
+    dogPreferredVetId,
+  } = dogProfile;
+  return SubProfileSchema.parse({
+    dogName,
+    dogWeightKg,
+    dogEverPregnant,
+    dogEverReceivedTransfusion,
+    dogPreferredVetId,
+  });
+}

--- a/src/lib/bark/models/dog-report-count.ts
+++ b/src/lib/bark/models/dog-report-count.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const DogReportCountSchema = z.object({
+  numReports: z.number().nonnegative(),
+});
+
+export type DogReportCount = z.infer<typeof DogReportCountSchema>;

--- a/src/lib/bark/models/sub-profile.ts
+++ b/src/lib/bark/models/sub-profile.ts
@@ -8,9 +8,9 @@ import { YesNoSchema } from "../enums/yes-no";
  *
  * -(a) Commented out fields are omitted.
  *
- * -(b) The schema for ever pregnant and ever received transfusion is
- * YesNoSchema, not YesNoUnknown. This is because sub profiles are used only
- * after a dog has a report.
+ * -(b) dogEverPregnant and dogEverReceivedTransfusion are YesNoSchema.
+ *
+ * -(c) dogWeightKg cannot be null.
  */
 export const SubProfileSchema = z.object({
   dogName: z.string(),

--- a/src/lib/bark/models/sub-profile.ts
+++ b/src/lib/bark/models/sub-profile.ts
@@ -1,15 +1,27 @@
 import { z } from "zod";
-import { DogProfileSchema } from "./dog-profile";
+import { YesNoSchema } from "../enums/yes-no";
 
 /**
- * The subset of DogProfile that can be modified after the first medical
- * report.
+ * The subset of DogProfile that can be modified after the first medical report.
+ *
+ * Note the following:
+ *
+ * -(a) Commented out fields are omitted.
+ *
+ * -(b) The schema for ever pregnant and ever received transfusion is
+ * YesNoSchema, not YesNoUnknown. This is because sub profiles are used only
+ * after a dog has a report.
  */
-export const SubProfileSchema = DogProfileSchema.omit({
-  dogBreed: true,
-  dogBirthday: true,
-  dogGender: true,
-  dogDea1Point1: true,
+export const SubProfileSchema = z.object({
+  dogName: z.string(),
+  // dogBreed: z.string(),
+  // dogBirthday: z.date(),
+  // dogGender: SpecifiedDogGenderSchema,
+  dogWeightKg: z.number(),
+  // dogDea1Point1: DogAntigenPresenceSchema,
+  dogEverPregnant: YesNoSchema,
+  dogEverReceivedTransfusion: YesNoSchema,
+  dogPreferredVetId: z.string(),
 });
 
 export type SubProfile = z.infer<typeof SubProfileSchema>;

--- a/src/lib/bark/operations/op-fetch-dog-report-count.ts
+++ b/src/lib/bark/operations/op-fetch-dog-report-count.ts
@@ -1,0 +1,20 @@
+import { Err, Ok, Result } from "@/lib/utilities/result";
+import { BarkContext } from "../bark-context";
+import { CODE } from "@/lib/utilities/bark-code";
+import { DogReportCount } from "../models/dog-report-count";
+import { selectDogReportCount } from "../queries/select-dog-report-count";
+
+export async function opFetchDogReportCount(
+  context: BarkContext,
+  args: { dogId: string },
+): Promise<Result<DogReportCount, typeof CODE.FAILED>> {
+  const { dbPool } = context;
+  const { dogId } = args;
+  try {
+    const res = await selectDogReportCount(dbPool, { dogId });
+    return Ok(res);
+  } catch (err) {
+    console.error(err);
+    return Err(CODE.FAILED);
+  }
+}

--- a/src/lib/bark/queries/select-dog-report-count.ts
+++ b/src/lib/bark/queries/select-dog-report-count.ts
@@ -1,0 +1,20 @@
+import { DbContext, dbQuery } from "@/lib/data/db-utils";
+import {
+  DogReportCount,
+  DogReportCountSchema,
+} from "../models/dog-report-count";
+
+export async function selectDogReportCount(
+  dbContext: DbContext,
+  args: { dogId: string },
+): Promise<DogReportCount> {
+  const { dogId } = args;
+  const sql = `
+  SELECT CAST(COUNT(*) AS INTEGER) as "numReports"
+  FROM reports
+  WHERE dog_id = $1
+  `;
+  const res = await dbQuery<DogReportCount>(dbContext, sql, [dogId]);
+  console.debug(res.rows[0]);
+  return DogReportCountSchema.parse(res.rows[0]);
+}

--- a/src/lib/utilities/bark-code.ts
+++ b/src/lib/utilities/bark-code.ts
@@ -13,6 +13,11 @@ export const CODE = {
   FAILED: "FAILED",
 
   /**
+   * When a certain feature is not implemented.
+   */
+  ERROR_NOT_IMPLEMENTED: "ERROR_NOT_IMPLEMENTED",
+
+  /**
    * When an expected account cannot be found. e.g. when sending OTP.
    */
   ERROR_ACCOUNT_NOT_FOUND: "ERROR_ACCOUNT_NOT_FOUND",

--- a/tests/_fixtures.ts
+++ b/tests/_fixtures.ts
@@ -83,6 +83,7 @@ import { DogProfile } from "@/lib/bark/models/dog-profile";
 import { SubProfile } from "@/lib/bark/models/sub-profile";
 import { getDogProfile } from "@/lib/user/actions/get-dog-profile";
 import { sprintf } from "sprintf-js";
+import { toSubProfile } from "@/lib/bark/mappers/to-sub-profile";
 
 export function ensureTimePassed(): void {
   const t0 = new Date().getTime();
@@ -546,8 +547,7 @@ export async function fetchDogInfo(
   const actor = getUserActor(dbPool, userId);
   const { result } = await getDogProfile(actor, dogId);
   const dogProfile = result!;
-  const { dogBreed, dogBirthday, dogGender, dogDea1Point1, ...subProfile } =
-    dogProfile;
+  const subProfile = toSubProfile(dogProfile);
   const { profileModificationTime } = await _getProfileModificationTime(
     dbPool,
     dogId,


### PR DESCRIPTION
When a dog has a report, users are allowed to edit only some of the profile fields. These are known as sub profiles. In this commit, the edit-dog page is updated to consider the existing report count, and when this is non-zero, it will present to the user a form for editing a sub-profile.