### PR TITLE
Adjust how vet options are presented and validated

### DIFF
--- a/src/app/user/(logged-in)/my-pets/_lib/components/general-dog-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/general-dog-form.tsx
@@ -84,15 +84,7 @@ export function GeneralDogForm(props: {
     ? toDogFormData(prefillData)
     : undefined;
   const form = useForm<DogFormData>({
-    resolver: zodResolver(
-      FORM_SCHEMA.extend({
-        // Only if there are more than 1 vet options, we require the user to select one. Else vet will be predetermine.
-        dogPreferredVetId:
-          vetOptions.length <= 1
-            ? FORM_SCHEMA.shape.dogPreferredVetId
-            : z.string().min(1, { message: "Please select an option" }),
-      }),
-    ),
+    resolver: zodResolver(FORM_SCHEMA),
     defaultValues: { ...EMPTY_VALUES, ...prefillFormValues },
   });
 

--- a/src/app/user/(logged-in)/my-pets/_lib/components/general-dog-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/general-dog-form.tsx
@@ -205,7 +205,7 @@ export function GeneralDogForm(props: {
           ]}
         />
 
-        {vetOptions.length > 1 && (
+        {vetOptions.length > 0 && (
           <BarkFormRadioGroup
             form={form}
             label="Preferred Donation Point"

--- a/src/app/user/(logged-in)/my-pets/_lib/components/general-dog-form.tsx
+++ b/src/app/user/(logged-in)/my-pets/_lib/components/general-dog-form.tsx
@@ -202,7 +202,15 @@ export function GeneralDogForm(props: {
             form={form}
             label="Preferred Donation Point"
             name="dogPreferredVetId"
-            options={vetOptions}
+            options={[
+              {
+                label: "None",
+                value: "",
+                description:
+                  "Select this option to exclude this dog from blood donation activities",
+              },
+              ...vetOptions,
+            ]}
           />
         )}
 

--- a/src/app/user/registration/_components/pet-form.tsx
+++ b/src/app/user/registration/_components/pet-form.tsx
@@ -184,7 +184,15 @@ export default function PetForm(props: {
             form={form}
             label="Select your preferred vet for blood profiling test and blood donation"
             name="dogPreferredVetId"
-            options={vetOptions}
+            options={[
+              {
+                label: "None",
+                value: "",
+                description:
+                  "Select this option to exclude this dog from blood donation activities",
+              },
+              ...vetOptions,
+            ]}
           />
         )}
 

--- a/src/app/user/registration/_components/pet-form.tsx
+++ b/src/app/user/registration/_components/pet-form.tsx
@@ -57,15 +57,7 @@ export default function PetForm(props: {
     nextLabel,
   } = props;
   const form = useForm<FormDataType>({
-    resolver: zodResolver(
-      FORM_SCHEMA.extend({
-        // Only if there are more than 1 vet options, we require the user to select one. Else vet will be predetermine.
-        dogPreferredVetId:
-          vetOptions.length <= 1
-            ? FORM_SCHEMA.shape.dogPreferredVetId
-            : z.string().min(1, { message: "Please select an option" }),
-      }),
-    ),
+    resolver: zodResolver(FORM_SCHEMA),
     defaultValues,
   });
 
@@ -187,7 +179,7 @@ export default function PetForm(props: {
           ]}
         />
 
-        {vetOptions.length > 1 && (
+        {vetOptions.length > 0 && (
           <BarkFormRadioGroup
             form={form}
             label="Select your preferred vet for blood profiling test and blood donation"

--- a/src/components/bark/bark-status-block.tsx
+++ b/src/components/bark/bark-status-block.tsx
@@ -137,10 +137,7 @@ export function BarkStatusBlock(props: {
     return (
       <div>
         <BarkStatusEligible />
-        <StatusMessage>
-          {dogName} is eligible for blood donation. Your preferred vet will
-          reachout to make an appointment.
-        </StatusMessage>
+        <StatusMessage>{dogName} is eligible for blood donation.</StatusMessage>
       </div>
     );
   }


### PR DESCRIPTION
This commit introduces two changes.

Firstly, the choice is now optional. So a "None" choice is always present.

Secondly, preferred vet options are presented so long as there is at least one vet option, not counting the None choice.