### PR TITLE
Fix BarkButton and unstable UI tests

### DIFF
--- a/e2e/_lib/ops/do-logout-sequence.ts
+++ b/e2e/_lib/ops/do-logout-sequence.ts
@@ -3,27 +3,25 @@ import { HeaderComponent } from "../pom/layout/header-component";
 import { UserLoginPage } from "../pom/pages/user-login-page";
 import { LogoutPage } from "../pom/pages/logout-page";
 import { PomContext } from "../pom/core/pom-object";
+import { doGetIsMobile } from "./do-get-is-mobile";
 
 /**
  * @param args.context Should have a Logout option in the Navbar
  * @returns UserLoginPage
  */
-export async function doLogoutSequence(
-  context: PomContext,
-): Promise<UserLoginPage> {
-  const navbar = new HeaderComponent(context);
-  await expect(navbar.locator()).toBeVisible();
-  if (await navbar.hamburgerButton().isVisible()) {
-    await navbar.hamburgerButton().click();
+export async function doLogoutSequence(context: PomContext) {
+  const isMobile = await doGetIsMobile(context);
+
+  const header = new HeaderComponent(context);
+  const pgLogout = new LogoutPage(context);
+  const pgUserLogin = new UserLoginPage(context);
+
+  if (isMobile) {
+    await header.hamburgerButton().click();
   }
-  await expect(navbar.logoutLink()).toBeVisible();
-  await navbar.logoutLink().click();
-
-  const logoutPage = new LogoutPage(context);
-  await logoutPage.checkUrl();
-  await logoutPage.logoutButton().click();
-
-  const userLoginPage = new UserLoginPage(context);
-  await userLoginPage.checkUrl();
-  return userLoginPage;
+  await expect(header.logoutLink()).toBeVisible();
+  await header.logoutLink().click();
+  await pgLogout.checkUrl();
+  await pgLogout.logoutButton().click();
+  await pgUserLogin.checkUrl();
 }

--- a/e2e/_lib/ops/do-schedule-appointment.ts
+++ b/e2e/_lib/ops/do-schedule-appointment.ts
@@ -24,4 +24,5 @@ export async function doScheduleAppointment(
     await pgScheduler.rightSidePane().scheduleButton().click();
     await expect(pgScheduler.rightSidePane().scheduledBadge()).toBeVisible();
   }
+  await pgScheduler.checkUrl();
 }

--- a/e2e/_lib/ops/do-submit-report.ts
+++ b/e2e/_lib/ops/do-submit-report.ts
@@ -41,6 +41,7 @@ export async function doSubmitReport(
       .fill(values.ineligibilityReason);
   }
   await pgSubmit.submitButton().click();
+  await pgList.checkUrl();
 }
 
 function _getBase(): BarkReportData {

--- a/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
+++ b/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
@@ -5,7 +5,6 @@ import { doLoginKnownVet } from "../_lib/ops/do-login-known-vet";
 import { doLogoutSequence } from "../_lib/ops/do-logout-sequence";
 import { UserMyPetsPage } from "../_lib/pom/pages/user-my-pets-page";
 import { UserViewDogPage } from "../_lib/pom/pages/user-view-dog-page";
-import { UserEditDogPage } from "../_lib/pom/pages/user-edit-dog-page";
 import { UserViewReportPage } from "../_lib/pom/pages/user-view-report-page";
 import { doScheduleAppointment } from "../_lib/ops/do-schedule-appointment";
 import { doSubmitReport } from "../_lib/ops/do-submit-report";

--- a/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
+++ b/src/app/user/(logged-in)/my-account/edit/_components/account-edit-form.tsx
@@ -80,7 +80,7 @@ export default function AccountEditForm({
           ]}
         />
         <div className="mt-6 flex flex-col gap-2 md:flex-row">
-          <BarkButton variant="brand" className="w-full md:w-40">
+          <BarkButton variant="brand" className="w-full md:w-40" type="submit">
             Save
           </BarkButton>
           <BarkButton

--- a/src/app/user/registration/_components/owner-form.tsx
+++ b/src/app/user/registration/_components/owner-form.tsx
@@ -126,6 +126,7 @@ export default function OwnerForm(props: {
           variant="brandInverse"
           className="mt-3"
           onClick={onRequestOtp}
+          type="button"
         >
           Send me an OTP
         </BarkButton>
@@ -167,6 +168,7 @@ export default function OwnerForm(props: {
             variant="brandInverse"
             onClick={onPrevClick}
             className="w-full"
+            type="button"
           >
             {prevLabel}
           </BarkButton>

--- a/src/app/user/registration/_components/pet-form.tsx
+++ b/src/app/user/registration/_components/pet-form.tsx
@@ -201,6 +201,7 @@ export default function PetForm(props: {
             variant="brandInverse"
             onClick={onPrevClick}
             className="w-full"
+            type="button"
           >
             {prevLabel}
           </BarkButton>

--- a/src/app/vet/_lib/components/call-card.tsx
+++ b/src/app/vet/_lib/components/call-card.tsx
@@ -109,6 +109,7 @@ export function CallCard(props: {
           variant="brand"
           onClick={() => submitOutcome(CALL_OUTCOME.APPOINTMENT)}
           className="w-full xl:w-40"
+          type="button"
         >
           Scheduled
         </BarkButton>
@@ -117,6 +118,7 @@ export function CallCard(props: {
           variant="brandInverse"
           onClick={() => submitOutcome(CALL_OUTCOME.DECLINED)}
           className="w-full xl:w-40"
+          type="button"
         >
           Declined
         </BarkButton>

--- a/src/app/vet/_lib/components/cancel-appointment-form.tsx
+++ b/src/app/vet/_lib/components/cancel-appointment-form.tsx
@@ -50,6 +50,7 @@ export function CancelAppointmentForm(props: { appointment: BarkAppointment }) {
           className="w-full md:w-40"
           variant="brand"
           onClick={onConfirm}
+          type="button"
         >
           Confirm
         </BarkButton>
@@ -57,6 +58,7 @@ export function CancelAppointmentForm(props: { appointment: BarkAppointment }) {
           className="w-full md:w-40"
           variant="brandInverse"
           onClick={onDoNotCancel}
+          type="button"
         >
           Do not cancel
         </BarkButton>

--- a/src/app/vet/_lib/components/general-report-form.tsx
+++ b/src/app/vet/_lib/components/general-report-form.tsx
@@ -406,6 +406,7 @@ export function GeneralReportForm(props: {
             className="w-full md:w-40"
             variant="brandInverse"
             onClick={onCancel}
+            type="button"
           >
             Cancel
           </BarkButton>

--- a/src/components/bark/bark-button.tsx
+++ b/src/components/bark/bark-button.tsx
@@ -2,19 +2,44 @@ import clsx from "clsx";
 import Link from "next/link";
 import { Button, buttonVariants } from "../ui/button";
 
-export function BarkButton(props: {
+type _BaseProps = {
   children: React.ReactNode;
   variant: "brand" | "brandInverse";
   className?: string;
-  href?: string;
-  onClick?: (() => Promise<void>) | (() => void);
-  type?: "button" | "submit" | "reset";
   disabled?: boolean;
-}) {
-  const { children, variant, className, disabled, href, onClick } = props;
-  const type = props.type ?? "button";
+};
 
-  if (href !== undefined && disabled !== true) {
+type _LinkProps = _BaseProps & {
+  href: string;
+  type?: undefined;
+  onClick?: undefined;
+};
+
+type _ButtonProps = _BaseProps & {
+  href?: undefined;
+  type: "button" | "submit" | "reset";
+  onClick?: (() => Promise<void>) | (() => void);
+};
+
+export function BarkButton(props: _LinkProps | _ButtonProps) {
+  const { children, variant, className, disabled, href, type, onClick } = props;
+
+  // Disabled button
+  if (disabled === true) {
+    return (
+      <Button
+        className={clsx("h-[60px]", className)}
+        variant={variant}
+        type="button"
+        disabled={true}
+      >
+        {children}
+      </Button>
+    );
+  }
+
+  // Link button
+  if (href !== undefined) {
     return (
       <Link
         className={clsx("h-[60px]", className, buttonVariants({ variant }))}
@@ -24,6 +49,8 @@ export function BarkButton(props: {
       </Link>
     );
   }
+
+  // Button with onClick
   if (onClick !== undefined) {
     return (
       <Button
@@ -37,6 +64,8 @@ export function BarkButton(props: {
       </Button>
     );
   }
+
+  // Just a button, typically "submit"
   return (
     <Button
       className={clsx("h-[60px]", className)}

--- a/src/components/bark/bark-button.tsx
+++ b/src/components/bark/bark-button.tsx
@@ -11,7 +11,8 @@ export function BarkButton(props: {
   type?: "button" | "submit" | "reset";
   disabled?: boolean;
 }) {
-  const { children, variant, className, type, disabled, href, onClick } = props;
+  const { children, variant, className, disabled, href, onClick } = props;
+  const type = props.type ?? "button";
 
   if (href !== undefined && disabled !== true) {
     return (

--- a/src/components/bark/login/bark-login-form.tsx
+++ b/src/components/bark/login/bark-login-form.tsx
@@ -122,6 +122,7 @@ export default function BarkLoginForm(props: {
           variant="brandInverse"
           className="mt-3 w-full md:w-48"
           onClick={onRequestOtp}
+          type="button"
         >
           Send me an OTP
         </BarkButton>


### PR DESCRIPTION
(1) BarkButton changes to addressing the following issues:

-(a) Saving form changes instead of cancelling (vet edit report page).

-(b) Login form validates OTP field when user clicks "Send me an OTP".

(1.1) Update BarkButton props to be either for the link kind or the button kind. For the link kind, 'href' is specified and 'type' and 'onClick' can be omitted or must be set to undefined. For the button kind, 'type' must be specified, 'href' can be omitted or must be undefined, and 'onClick' is optional.

(1.2) Update all usage that isn't a link—i.e. no 'href'—to specify 'type' as either 'button' or 'submit'. Next Build will fail if we do not provide the correct props.

(2) Fixed some flaky UI tests. Specifically, the "user can view report and edit sub-profile" test. Here, the "doSubmitReport" sequence was not checking the URL after clicking the submit button. Thus the page transitions raced with the expectations of the follow-up doLogoutSequence. Changes here include the following:

-(a) Updates to doLogoutSequence to use doGetIsMobile

-(b) Add checkUrl in at the end of some of the UI test ops.

