### PR TITLE
Address UI Test Stability

### DIFF
--- a/e2e/_lib/ops/do-submit-report.ts
+++ b/e2e/_lib/ops/do-submit-report.ts
@@ -9,6 +9,7 @@ import {
 } from "@/lib/bark/models/bark-report-data";
 import { POS_NEG_NIL } from "@/lib/bark/enums/pos-neg-nil";
 import { REPORTED_INELIGIBILITY } from "@/lib/bark/enums/reported-ineligibility";
+import { ToastComponent } from "../pom/layout/toast-component";
 
 export async function doSubmitReport(
   context: PomContext,
@@ -20,6 +21,7 @@ export async function doSubmitReport(
   const nav = new NavComponent(context);
   const pgList = new VetAppointmentListPage(context);
   const pgSubmit = new VetAppointmentSubmitReportPage(context);
+  const toast = new ToastComponent(context);
 
   await nav.vetAppointmentsOption().click();
   await pgList.checkUrl();
@@ -41,6 +43,8 @@ export async function doSubmitReport(
       .fill(values.ineligibilityReason);
   }
   await pgSubmit.submitButton().click();
+  await expect(toast.locator()).toContainText("Submitted");
+  await toast.closeButton().click();
   await pgList.checkUrl();
 }
 

--- a/e2e/_lib/ops/do-submit-report.ts
+++ b/e2e/_lib/ops/do-submit-report.ts
@@ -1,3 +1,4 @@
+import { expect } from "@playwright/test";
 import { SGT_UI_DATE, formatDateTime } from "@/lib/utilities/bark-time";
 import { PomContext } from "../pom/core/pom-object";
 import { NavComponent } from "../pom/layout/nav-component";

--- a/e2e/user/user-can-edit-incomplete-dog.spec.ts
+++ b/e2e/user/user-can-edit-incomplete-dog.spec.ts
@@ -4,6 +4,7 @@ import { UserEditDogPage } from "../_lib/pom/pages/user-edit-dog-page";
 import { UserViewDogPage } from "../_lib/pom/pages/user-view-dog-page";
 import { initPomContext } from "../_lib/init/init-pom-context";
 import { doRegister } from "../_lib/ops/do-register";
+import { ToastComponent } from "../_lib/pom/layout/toast-component";
 
 test("user can edit incomplete dog profile", async ({ page }) => {
   const context = await initPomContext({ page });
@@ -14,6 +15,7 @@ test("user can edit incomplete dog profile", async ({ page }) => {
   const pgList = new UserMyPetsPage(context);
   const pgView = new UserViewDogPage(context);
   const pgEdit = new UserEditDogPage(context);
+  const toast = new ToastComponent(context);
 
   // Starting at the dog list page, user should see that their dog's profile is
   // incomplete.
@@ -32,6 +34,8 @@ test("user can edit incomplete dog profile", async ({ page }) => {
   await pgEdit.dogEverReceivedTransfusionOption_NO().click();
   await pgEdit.dogEverPregnantOption_NO().click();
   await pgEdit.saveButton().click();
+  await expect(toast.locator()).toContainText("Saved");
+  await toast.closeButton().click();
 
   // Navigate back to list
   await pgView.checkUrl();

--- a/e2e/user/user-can-set-weight-to-empty.spec.ts
+++ b/e2e/user/user-can-set-weight-to-empty.spec.ts
@@ -4,6 +4,7 @@ import { UserEditDogPage } from "../_lib/pom/pages/user-edit-dog-page";
 import { UserViewDogPage } from "../_lib/pom/pages/user-view-dog-page";
 import { initPomContext } from "../_lib/init/init-pom-context";
 import { doRegister } from "../_lib/ops/do-register";
+import { ToastComponent } from "../_lib/pom/layout/toast-component";
 
 test("user can set weight to empty", async ({ page }) => {
   const context = await initPomContext({ page });
@@ -14,6 +15,7 @@ test("user can set weight to empty", async ({ page }) => {
   const pgList = new UserMyPetsPage(context);
   const pgView = new UserViewDogPage(context);
   const pgEdit = new UserEditDogPage(context);
+  const toast = new ToastComponent(context);
 
   // Navigate to Edit Page
   await pgList.checkUrl();
@@ -26,6 +28,8 @@ test("user can set weight to empty", async ({ page }) => {
   await pgEdit.checkUrl();
   await pgEdit.dogWeightField().fill("");
   await pgEdit.saveButton().click();
+  await expect(toast.locator()).toContainText("Saved");
+  await toast.closeButton().click();
 
   // Should be back at the view dog page.
   await pgView.checkUrl();

--- a/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
+++ b/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
@@ -18,6 +18,7 @@ import {
 } from "@/lib/utilities/bark-time";
 import { UserEditSubProfilePage } from "../_lib/pom/pages/user-edit-sub-profile-page";
 import { YES_NO } from "@/lib/bark/enums/yes-no";
+import { ToastComponent } from "../_lib/pom/layout/toast-component";
 
 test("user can view report and edit sub-profile", async ({
   page,
@@ -59,6 +60,7 @@ test("user can view report and edit sub-profile", async ({
   const pgViewDog = new UserViewDogPage(context);
   const pgEdit = new UserEditSubProfilePage(context);
   const pgViewReport = new UserViewReportPage(context);
+  const toast = new ToastComponent(context);
 
   // Verify that dog's weight is the registration dog weight, because
   // registration dog weight is the most recent.
@@ -86,6 +88,8 @@ test("user can view report and edit sub-profile", async ({
   await pgEdit.dogEverReceivedTransfusionOption(YES_NO.YES).click();
   await pgEdit.dogWeightField().fill(newWeight);
   await pgEdit.saveButton().click();
+  await expect(toast.locator()).toContainText("Saved");
+  await toast.closeButton().click();
 
   // Verify the edits, we should be in the view dog page again.
   await pgViewDog.checkUrl();

--- a/e2e/user/user-can-view-then-edit-dog.ts
+++ b/e2e/user/user-can-view-then-edit-dog.ts
@@ -1,9 +1,10 @@
-import { test } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { UserMyPetsPage } from "../_lib/pom/pages/user-my-pets-page";
 import { UserEditDogPage } from "../_lib/pom/pages/user-edit-dog-page";
 import { UserViewDogPage } from "../_lib/pom/pages/user-view-dog-page";
 import { initPomContext } from "../_lib/init/init-pom-context";
 import { doLoginKnownUser } from "../_lib/ops/do-login-known-user";
+import { ToastComponent } from "../_lib/pom/layout/toast-component";
 
 test("user can list, view, edit, cancel, edit, submit, back, list", async ({
   page,
@@ -15,6 +16,7 @@ test("user can list, view, edit, cancel, edit, submit, back, list", async ({
   const myPetsPage = new UserMyPetsPage(context);
   const editDogPage = new UserEditDogPage(context);
   const viewDogPage = new UserViewDogPage(context);
+  const toast = new ToastComponent(context);
 
   await myPetsPage.checkUrl();
   await myPetsPage.dogCardItem(dogName).locator().click();
@@ -30,6 +32,8 @@ test("user can list, view, edit, cancel, edit, submit, back, list", async ({
 
   await editDogPage.checkUrl();
   await editDogPage.saveButton().click();
+  await expect(toast.locator()).toContainText("Saved");
+  await toast.closeButton().click();
 
   await viewDogPage.checkUrl();
   await viewDogPage.backButton().click();

--- a/e2e/vet/call-task-uses-latest-values.spec.ts
+++ b/e2e/vet/call-task-uses-latest-values.spec.ts
@@ -11,6 +11,7 @@ import { ApiClient } from "../_lib/pom/api/api-client";
 import { SGT_UI_DATE, formatDateTime } from "@/lib/utilities/bark-time";
 import { initPomContext } from "../_lib/init/init-pom-context";
 import { doRegister } from "../_lib/ops/do-register";
+import { ToastComponent } from "../_lib/pom/layout/toast-component";
 
 test("call task uses latest values", async ({ page, request }) => {
   const context = await initPomContext({ page });
@@ -27,6 +28,7 @@ test("call task uses latest values", async ({ page, request }) => {
   const pgAppointments = new VetAppointmentListPage(context);
   const pgSubmit = new VetAppointmentSubmitReportPage(context);
   const sidebar = new NavComponent(context);
+  const toast = new ToastComponent(context);
 
   await pgSchedule.checkUrl();
   await pgSchedule.dogCard(dogName).locator().click();
@@ -70,6 +72,8 @@ test("call task uses latest values", async ({ page, request }) => {
   await pgSubmit.dogWeightField().fill(newWeight);
   await pgSubmit.dogHeartwormOption_NEGATIVE().click();
   await pgSubmit.submitButton().click();
+  await expect(toast.locator()).toContainText("Submitted");
+  await toast.closeButton().click();
 
   await pgAppointments.checkUrl();
   await sidebar.vetScheduleOption().click();

--- a/e2e/vet/vet-can-edit-report.spec.ts
+++ b/e2e/vet/vet-can-edit-report.spec.ts
@@ -8,6 +8,7 @@ import { VetReportListPage } from "../_lib/pom/pages/vet-report-list-page";
 import { PomContext } from "../_lib/pom/core/pom-object";
 import { VetReportEditPage } from "../_lib/pom/pages/vet-report-edit-page";
 import { VetReportViewPage } from "../_lib/pom/pages/vet-report-view-page";
+import { ToastComponent } from "../_lib/pom/layout/toast-component";
 
 test("vet can edit report", async ({ page }) => {
   const context = await initPomContext({ page });
@@ -42,6 +43,7 @@ async function givenSubmittedReport(context: PomContext): Promise<{
   const pgSubmit = new VetAppointmentSubmitReportPage(context);
   const sideBarOrDock = new NavComponent(context);
   const pgReportList = new VetReportListPage(context);
+  const toast = new ToastComponent(context);
 
   await pgList.checkUrl();
   await pgList.appointmentCard({ dogName }).submitReportButton().click();
@@ -55,6 +57,8 @@ async function givenSubmittedReport(context: PomContext): Promise<{
   await pgSubmit.dogDea1Point1_POSITIVE().click();
   await pgSubmit.dogDidDonateBlood_YES().click();
   await pgSubmit.submitButton().click();
+  await expect(toast.locator()).toContainText("Submitted");
+  await toast.closeButton().click();
 
   await pgList.checkUrl();
   await expect(pgList.appointmentCard({ dogName }).locator()).not.toBeVisible();
@@ -75,6 +79,7 @@ async function changeBloodTypeToNegative(
   const pgList = new VetReportListPage(context);
   const pgView = new VetReportViewPage(context);
   const pgEdit = new VetReportEditPage(context);
+  const toast = new ToastComponent(context);
 
   await pgList.checkUrl();
   await pgList.reportCard({ dogName }).locator().click();
@@ -84,6 +89,8 @@ async function changeBloodTypeToNegative(
 
   await pgEdit.dogDea1Point1_NEGATIVE().click();
   await pgEdit.submitButton().click();
+  await expect(toast.locator()).toContainText("Saved");
+  await toast.closeButton().click();
 
   await pgView.checkUrl();
   await pgView.backButton().click();

--- a/e2e/vet/vet-can-edit-report.spec.ts
+++ b/e2e/vet/vet-can-edit-report.spec.ts
@@ -49,6 +49,7 @@ async function givenSubmittedReport(context: PomContext): Promise<{
   await pgList.appointmentCard({ dogName }).submitReportButton().click();
 
   await pgSubmit.checkUrl();
+  await expect(pgSubmit.submitButton()).toBeVisible();
   await pgSubmit.visitDateField().fill("6 May 2024");
   await pgSubmit.dogWeightField().fill("27.89");
   await pgSubmit.dogBcsSelector().click();
@@ -86,6 +87,7 @@ async function changeBloodTypeToNegative(
   await pgView.checkUrl();
   await pgView.editButton().click();
   await pgEdit.checkUrl();
+  await expect(pgEdit.submitButton()).toBeVisible();
 
   await pgEdit.dogDea1Point1_NEGATIVE().click();
   await pgEdit.submitButton().click();
@@ -93,6 +95,7 @@ async function changeBloodTypeToNegative(
   await toast.closeButton().click();
 
   await pgView.checkUrl();
+  await expect(pgView.backButton()).toBeVisible();
   await pgView.backButton().click();
   await pgList.checkUrl();
 }

--- a/e2e/vet/vet-can-submit-report.spec.ts
+++ b/e2e/vet/vet-can-submit-report.spec.ts
@@ -5,33 +5,37 @@ import { VetAppointmentListPage } from "../_lib/pom/pages/vet-appointment-list-p
 import { VetAppointmentSubmitReportPage } from "../_lib/pom/pages/vet-appointment-submit-report-page";
 import { NavComponent } from "../_lib/pom/layout/nav-component";
 import { VetReportListPage } from "../_lib/pom/pages/vet-report-list-page";
+import { ToastComponent } from "../_lib/pom/layout/toast-component";
 
 test("vet can submit report", async ({ page }) => {
   const context = await initPomContext({ page });
   const { dogName } = await doCreateAppointment(context);
 
-  const pg1 = new VetAppointmentListPage(context);
-  await pg1.checkUrl();
-  await pg1.appointmentCard({ dogName }).submitReportButton().click();
-
-  const pg2 = new VetAppointmentSubmitReportPage(context);
-  await pg2.checkUrl();
-  await pg2.visitDateField().fill("11 May 2024");
-  await pg2.dogWeightField().fill("28.61");
-  await pg2.dogBcsSelector().click();
-  await pg2.dogBcsOption8().click();
-  await pg2.dogHeartwormOption_NEGATIVE().click();
-  await pg2.dogDea1Point1_POSITIVE().click();
-  await pg2.dogDidDonateBlood_YES().click();
-  await pg2.submitButton().click();
-
-  const pg3 = new VetAppointmentListPage(context);
-  await pg3.checkUrl();
-  await expect(pg3.appointmentCard({ dogName }).locator()).not.toBeVisible();
-
+  const pgList = new VetAppointmentListPage(context);
+  const pgSubmit = new VetAppointmentSubmitReportPage(context);
+  const toast = new ToastComponent(context);
   const nav = new NavComponent(context);
+  const pgReportList = new VetReportListPage(context);
+
+  await pgList.checkUrl();
+  await pgList.appointmentCard({ dogName }).submitReportButton().click();
+
+  await pgSubmit.checkUrl();
+  await pgSubmit.visitDateField().fill("11 May 2024");
+  await pgSubmit.dogWeightField().fill("28.61");
+  await pgSubmit.dogBcsSelector().click();
+  await pgSubmit.dogBcsOption8().click();
+  await pgSubmit.dogHeartwormOption_NEGATIVE().click();
+  await pgSubmit.dogDea1Point1_POSITIVE().click();
+  await pgSubmit.dogDidDonateBlood_YES().click();
+  await pgSubmit.submitButton().click();
+  await expect(toast.locator()).toContainText("Submitted");
+  await toast.closeButton().click();
+
+  await pgList.checkUrl();
+  await expect(pgList.appointmentCard({ dogName }).locator()).not.toBeVisible();
+
   await nav.vetReportsOption().click();
 
-  const pg4 = new VetReportListPage(context);
-  await expect(pg4.reportCard({ dogName }).locator()).toBeVisible();
+  await expect(pgReportList.reportCard({ dogName }).locator()).toBeVisible();
 });

--- a/e2e/vet/vet-can-submit-report.spec.ts
+++ b/e2e/vet/vet-can-submit-report.spec.ts
@@ -21,6 +21,7 @@ test("vet can submit report", async ({ page }) => {
   await pgList.appointmentCard({ dogName }).submitReportButton().click();
 
   await pgSubmit.checkUrl();
+  await expect(pgSubmit.submitButton()).toBeVisible();
   await pgSubmit.visitDateField().fill("11 May 2024");
   await pgSubmit.dogWeightField().fill("28.61");
   await pgSubmit.dogBcsSelector().click();

--- a/e2e/vet/vet-can-view-report.spec.ts
+++ b/e2e/vet/vet-can-view-report.spec.ts
@@ -6,6 +6,7 @@ import { VetAppointmentSubmitReportPage } from "../_lib/pom/pages/vet-appointmen
 import { NavComponent } from "../_lib/pom/layout/nav-component";
 import { VetReportListPage } from "../_lib/pom/pages/vet-report-list-page";
 import { VetReportViewPage } from "../_lib/pom/pages/vet-report-view-page";
+import { ToastComponent } from "../_lib/pom/layout/toast-component";
 
 test("vet can view report", async ({ page }) => {
   const context = await initPomContext({ page });
@@ -16,6 +17,7 @@ test("vet can view report", async ({ page }) => {
   const sideBarOrDock = new NavComponent(context);
   const pgReportList = new VetReportListPage(context);
   const pgView = new VetReportViewPage(context);
+  const toast = new ToastComponent(context);
 
   // Submit a report
   await pgAppointmentList.checkUrl();
@@ -35,6 +37,8 @@ test("vet can view report", async ({ page }) => {
   await pgSubmit.dogEligibility_TEMPORARILY_INELIGIBLE().click();
   await pgSubmit.ineligibilityExpiryDateField().fill("1 Feb 2022");
   await pgSubmit.submitButton().click();
+  await expect(toast.locator()).toContainText("Submitted");
+  await toast.closeButton().click();
   await pgAppointmentList.checkUrl();
 
   // Navigate to view report page


### PR DESCRIPTION
Changes

- Optimise isProtocolFor to check just the string prefix for `_ENC2_`

Fixes

- Wait for toast to appear and then close it after submitting a report.
- Check for buttons after checkURL. (What we really need is checkReady.)