### PR TITLE
BARK-7443: Use latest non-null weight

### DIFF
--- a/db/V4__ref_latest_values.sql
+++ b/db/V4__ref_latest_values.sql
@@ -103,7 +103,8 @@ AS (
         tDog.dog_id,
         tUser.user_id,
         CASE
-            WHEN tReport.visit_time IS NULL THEN tDog.dog_weight_kg
+            WHEN tReport.dog_weight_kg IS NULL THEN tDog.dog_weight_kg
+            WHEN tDog.dog_weight_kg IS NULL THEN tReport.dog_weight_kg
             WHEN tReport.visit_time > tDog.profile_modification_time THEN tReport.dog_weight_kg
             ELSE tDog.dog_weight_kg
         END as latest_dog_weight_kg,


### PR DESCRIPTION
The latest_values view is updated to use the latest non-null weight. This solves the issue whereby latest weight is stuck as null until a report exists with visit time more recent than the dog's profile modification time.