### PR TITLE
BARK-5778: Improve UI Test Stability

### DIFF
--- a/e2e/_lib/ops/do-create-appointment.ts
+++ b/e2e/_lib/ops/do-create-appointment.ts
@@ -34,7 +34,7 @@ export async function doCreateAppointment(
   await nav.vetAppointmentsOption().click();
 
   const pg2 = new VetAppointmentListPage(context);
-  await pg2.checkUrl();
+  await pg2.checkReady();
 
   console.log({
     dogName,

--- a/e2e/_lib/ops/do-login-known-admin.ts
+++ b/e2e/_lib/ops/do-login-known-admin.ts
@@ -14,7 +14,7 @@ export async function doLoginKnownAdmin(context: PomContext): Promise<{
   await footer.adminLoginLink().click();
 
   const pg = new AdminLoginPage(context);
-  await pg.checkUrl();
+  await pg.checkReady();
   await pg.emailField().fill(knownAdmin.adminEmail);
   await pg.otpField().fill("000000");
   await pg.loginButton().click();

--- a/e2e/_lib/ops/do-login-known-vet.ts
+++ b/e2e/_lib/ops/do-login-known-vet.ts
@@ -14,7 +14,7 @@ export async function doLoginKnownVet(context: PomContext): Promise<{
   await footer.vetLoginLink().click();
 
   const pg = new VetLoginPage(context);
-  await pg.checkUrl();
+  await pg.checkReady();
   await pg.emailField().fill(knownVet.vetEmail);
   await pg.otpField().fill("000000");
   await pg.loginButton().click();

--- a/e2e/_lib/ops/do-logout-sequence.ts
+++ b/e2e/_lib/ops/do-logout-sequence.ts
@@ -21,7 +21,7 @@ export async function doLogoutSequence(context: PomContext) {
   }
   await expect(header.logoutLink()).toBeVisible();
   await header.logoutLink().click();
-  await pgLogout.checkUrl();
+  await pgLogout.checkReady();
   await pgLogout.logoutButton().click();
-  await pgUserLogin.checkUrl();
+  await pgUserLogin.checkReady();
 }

--- a/e2e/_lib/ops/do-register.ts
+++ b/e2e/_lib/ops/do-register.ts
@@ -29,7 +29,7 @@ export async function doRegister(
   const pgMyPets = new UserMyPetsPage(context);
 
   await context.page.goto(pgReg.url());
-  await pgReg.checkUrl();
+  await pgReg.checkReady();
 
   // Pet Form
   await pgReg.dogNameField().fill(dogName);
@@ -74,7 +74,7 @@ export async function doRegister(
   await pgReg.enterDashboardButton().click();
 
   // Should be at my pets
-  await pgMyPets.checkUrl();
+  await pgMyPets.checkReady();
 
   const reg: GeneratedRegistration = { dog, user };
   console.debug(reg);

--- a/e2e/_lib/ops/do-schedule-appointment.ts
+++ b/e2e/_lib/ops/do-schedule-appointment.ts
@@ -15,7 +15,7 @@ export async function doScheduleAppointment(
   const pgScheduler = new VetSchedulePage(context);
 
   await nav.vetScheduleOption().click();
-  await pgScheduler.checkUrl();
+  await pgScheduler.checkReady();
   await pgScheduler.dogCard(dogName).locator().click();
   if (isMobile) {
     await pgScheduler.dogCard(dogName).scheduleButton().click();
@@ -24,5 +24,5 @@ export async function doScheduleAppointment(
     await pgScheduler.rightSidePane().scheduleButton().click();
     await expect(pgScheduler.rightSidePane().scheduledBadge()).toBeVisible();
   }
-  await pgScheduler.checkUrl();
+  await pgScheduler.checkReady();
 }

--- a/e2e/_lib/ops/do-submit-report.ts
+++ b/e2e/_lib/ops/do-submit-report.ts
@@ -25,7 +25,7 @@ export async function doSubmitReport(
   const toast = new ToastComponent(context);
 
   await nav.vetAppointmentsOption().click();
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await pgList.appointmentCard({ dogName }).submitReportButton().click();
   await pgSubmit.checkUrl();
 
@@ -46,7 +46,7 @@ export async function doSubmitReport(
   await pgSubmit.submitButton().click();
   await expect(toast.locator()).toContainText("Submitted");
   await toast.closeButton().click();
-  await pgList.checkUrl();
+  await pgList.checkReady();
 }
 
 function _getBase(): BarkReportData {

--- a/e2e/_lib/ops/do-submit-report.ts
+++ b/e2e/_lib/ops/do-submit-report.ts
@@ -27,7 +27,7 @@ export async function doSubmitReport(
   await nav.vetAppointmentsOption().click();
   await pgList.checkReady();
   await pgList.appointmentCard({ dogName }).submitReportButton().click();
-  await pgSubmit.checkUrl();
+  await pgSubmit.checkReady();
 
   await pgSubmit
     .visitDateField()

--- a/e2e/_lib/ops/do-user-login-sequence.ts
+++ b/e2e/_lib/ops/do-user-login-sequence.ts
@@ -15,7 +15,7 @@ export async function doUserLoginSequence(
   const { userEmail } = args;
 
   const pg1 = new UserLoginPage(context);
-  await pg1.checkUrl();
+  await pg1.checkReady();
   await pg1.emailField().fill(userEmail);
   await pg1.sendMeAnOtpButton().click();
   await expect(pg1.otpSentMessage()).toBeVisible();
@@ -23,6 +23,6 @@ export async function doUserLoginSequence(
   await pg1.loginButton().click();
 
   const pg2 = new UserMyPetsPage(context);
-  await pg2.checkUrl();
+  await pg2.checkReady();
   return pg2;
 }

--- a/e2e/_lib/pom/core/pom-dynamic-page.ts
+++ b/e2e/_lib/pom/core/pom-dynamic-page.ts
@@ -6,7 +6,20 @@ export abstract class PomDynamicPage extends PomObject {
   abstract urlRegex(): RegExp;
 
   async checkReady() {
+    await this.checkUrl();
+    await this.checkPageLoaded();
+  }
+
+  async checkUrl() {
     await expect(this.page()).toHaveURL(this.urlRegex());
+  }
+
+  /**
+   * Override this if there are things to check that demonstrate the page has
+   * loaded successfully.
+   */
+  async checkPageLoaded() {
+    // Do nothing.
   }
 
   exactText(text: string): Locator {

--- a/e2e/_lib/pom/core/pom-dynamic-page.ts
+++ b/e2e/_lib/pom/core/pom-dynamic-page.ts
@@ -5,7 +5,7 @@ import { Locator, expect } from "@playwright/test";
 export abstract class PomDynamicPage extends PomObject {
   abstract urlRegex(): RegExp;
 
-  async checkUrl() {
+  async checkReady() {
     await expect(this.page()).toHaveURL(this.urlRegex());
   }
 

--- a/e2e/_lib/pom/core/pom-page.ts
+++ b/e2e/_lib/pom/core/pom-page.ts
@@ -5,13 +5,13 @@ import { Locator, expect } from "@playwright/test";
 export abstract class PomPage extends PomObject {
   abstract url(): string;
 
-  async checkUrl() {
+  async checkReady() {
     await expect(this.page()).toHaveURL(this.url());
   }
 
   async goto() {
     await this.page().goto(this.url());
-    await this.checkUrl();
+    await this.checkReady();
   }
 
   exactText(text: string): Locator {

--- a/e2e/_lib/pom/core/pom-page.ts
+++ b/e2e/_lib/pom/core/pom-page.ts
@@ -6,7 +6,20 @@ export abstract class PomPage extends PomObject {
   abstract url(): string;
 
   async checkReady() {
+    await this.checkUrl();
+    await this.checkPageLoaded();
+  }
+
+  async checkUrl() {
     await expect(this.page()).toHaveURL(this.url());
+  }
+
+  /**
+   * Override this if there are things to check that demonstrate the page has
+   * loaded successfully.
+   */
+  async checkPageLoaded() {
+    // Do nothing.
   }
 
   async goto() {

--- a/e2e/_lib/pom/pages/user-my-pets-page.ts
+++ b/e2e/_lib/pom/pages/user-my-pets-page.ts
@@ -1,4 +1,4 @@
-import { Locator } from "@playwright/test";
+import { Locator, expect } from "@playwright/test";
 import { RoutePath } from "@/lib/route-path";
 import { PomContext } from "../core/pom-object";
 import { PomComponent } from "../core/pom-component";
@@ -7,6 +7,10 @@ import { PomPage } from "../core/pom-page";
 export class UserMyPetsPage extends PomPage {
   url(): string {
     return this.website().urlOf(RoutePath.USER_MY_PETS);
+  }
+
+  async checkPageLoaded(): Promise<void> {
+    await expect(this.addPetButton()).toBeVisible();
   }
 
   dogCardItem(dogName: string): DogCardItem {

--- a/e2e/_lib/pom/pages/user-view-dog-page.ts
+++ b/e2e/_lib/pom/pages/user-view-dog-page.ts
@@ -1,11 +1,15 @@
 import { RoutePath } from "@/lib/route-path";
 import { PomDynamicPage } from "../core/pom-dynamic-page";
-import { Locator } from "@playwright/test";
+import { Locator, expect } from "@playwright/test";
 import { SGT_UI_DATE, formatDateTime } from "@/lib/utilities/bark-time";
 
 export class UserViewDogPage extends PomDynamicPage {
   urlRegex(): RegExp {
     return RoutePath.USER_VIEW_DOG_REGEX;
+  }
+
+  async checkPageLoaded(): Promise<void> {
+    await expect(this.editButton()).toBeVisible();
   }
 
   dogNameHeader(name: string): Locator {

--- a/e2e/_lib/pom/pages/user-view-report-page.ts
+++ b/e2e/_lib/pom/pages/user-view-report-page.ts
@@ -1,10 +1,14 @@
 import { RoutePath } from "@/lib/route-path";
 import { PomDynamicPage } from "../core/pom-dynamic-page";
-import { Locator } from "@playwright/test";
+import { Locator, expect } from "@playwright/test";
 
 export class UserViewReportPage extends PomDynamicPage {
   urlRegex(): RegExp {
     return RoutePath.USER_VIEW_REPORT_REGEX;
+  }
+
+  async checkPageLoaded(): Promise<void> {
+    await expect(this.backButton()).toBeVisible();
   }
 
   dogBreedItem(): Locator {

--- a/e2e/user/user-can-add-dog.spec.ts
+++ b/e2e/user/user-can-add-dog.spec.ts
@@ -15,10 +15,10 @@ test("user can register, login, add dog, and see it in my-pets", async ({
   await doRegister(context);
 
   const pg1 = new UserMyPetsPage(context);
-  await pg1.checkUrl();
+  await pg1.checkReady();
   await pg1.addPetButton().click();
   const pg2 = new UserAddDogPage(context);
-  await pg2.checkUrl();
+  await pg2.checkReady();
 
   // WHEN dog details are filled in and saved
   const dogGender = "FEMALE";
@@ -52,7 +52,7 @@ test("user can register, login, add dog, and see it in my-pets", async ({
 
   // THEN
   const pg3 = new UserMyPetsPage(context);
-  await pg3.checkUrl();
+  await pg3.checkReady();
   const card = pg3.dogCardItem(dogName);
   await expect(card.locator()).toBeVisible();
   await expect(card.exactText("Eligible")).toBeVisible();

--- a/e2e/user/user-can-cancel-add-dog.spec.ts
+++ b/e2e/user/user-can-cancel-add-dog.spec.ts
@@ -14,10 +14,10 @@ test("user can register, login, add dog but cancel, and not should not see new d
   await doRegister(context);
 
   const pg1 = new UserMyPetsPage(context);
-  await pg1.checkUrl();
+  await pg1.checkReady();
   await pg1.addPetButton().click();
   const pg2 = new UserAddDogPage(context);
-  await pg2.checkUrl();
+  await pg2.checkReady();
 
   // WHEN dog details are filled in
   const dogGender = "FEMALE";
@@ -40,7 +40,7 @@ test("user can register, login, add dog but cancel, and not should not see new d
 
   // THEN
   const pg3 = new UserMyPetsPage(context);
-  await pg3.checkUrl();
+  await pg3.checkReady();
   const card = pg3.dogCardItem(dogName);
   await expect(card.locator()).not.toBeVisible();
 });

--- a/e2e/user/user-can-cancel-edit-account.spec.ts
+++ b/e2e/user/user-can-cancel-edit-account.spec.ts
@@ -19,7 +19,7 @@ test("user can register, edit account details, but click cancel, and should see 
   const pgEdit = new UserMyAccountEditPage(context);
 
   await nav.myAcountOption().click();
-  await pgAcc.checkUrl();
+  await pgAcc.checkReady();
 
   await expect(pgAcc.exactText(userName)).toBeVisible();
   await expect(pgAcc.residencyItem()).toHaveValue("Singapore");
@@ -28,7 +28,7 @@ test("user can register, edit account details, but click cancel, and should see 
 
   // WHEN user clicks on edit button, navigate to edit page
   await pgAcc.editButton().click();
-  await pgEdit.checkUrl();
+  await pgEdit.checkReady();
 
   // BUT cancelled, navigate back to account page
   await pgEdit.userNameField().fill("New Name");
@@ -37,7 +37,7 @@ test("user can register, edit account details, but click cancel, and should see 
   await pgEdit.cancelButton().click();
 
   // THEN
-  await pgAcc.checkUrl();
+  await pgAcc.checkReady();
   await expect(pgAcc.exactText(userName)).toBeVisible();
   await expect(pgAcc.residencyItem()).toHaveValue("Singapore");
   await expect(pgAcc.emailItem()).toHaveValue(userEmail);

--- a/e2e/user/user-can-cancel-edit-dog.spec.ts
+++ b/e2e/user/user-can-cancel-edit-dog.spec.ts
@@ -19,7 +19,7 @@ test("user can cancel edit dog profile", async ({ page }) => {
   await pgList.checkReady();
   await pgList.dogCardItem(dogName).locator().click();
   await pgView.editButton().click();
-  await pgEdit.checkUrl();
+  await pgEdit.checkReady();
 
   // Fill in form
   await expect(pgEdit.dogNameField()).toHaveValue(dogName);
@@ -33,7 +33,7 @@ test("user can cancel edit dog profile", async ({ page }) => {
 
   // Cancel
   await pgEdit.cancelButton().click();
-  await pgView.checkUrl();
+  await pgView.checkReady();
 
   // Navigate back to edit dog to verify no changes
   await pgView.editButton().click();

--- a/e2e/user/user-can-cancel-edit-dog.spec.ts
+++ b/e2e/user/user-can-cancel-edit-dog.spec.ts
@@ -16,7 +16,7 @@ test("user can cancel edit dog profile", async ({ page }) => {
   const pgEdit = new UserEditDogPage(context);
 
   // Navigate to edit dog page
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await pgList.dogCardItem(dogName).locator().click();
   await pgView.editButton().click();
   await pgEdit.checkUrl();

--- a/e2e/user/user-can-cancel-logout.spec.ts
+++ b/e2e/user/user-can-cancel-logout.spec.ts
@@ -18,7 +18,7 @@ test("user can cancel logout", async ({ page }) => {
   // Navigate to My Account page first. We expect to return here if we cancel
   // the logout.
   await nav.myAcountOption().click();
-  await pgMyAcc.checkUrl();
+  await pgMyAcc.checkReady();
 
   if (await header.hamburgerButton().isVisible()) {
     await header.hamburgerButton().click();
@@ -26,10 +26,10 @@ test("user can cancel logout", async ({ page }) => {
   await expect(header.logoutLink()).toBeVisible();
   await header.logoutLink().click();
 
-  await pgLogout.checkUrl();
+  await pgLogout.checkReady();
   await expect(pgLogout.cancelButton()).toBeVisible();
   await pgLogout.cancelButton().click();
 
   // Should be back at my account page.
-  await pgMyAcc.checkUrl();
+  await pgMyAcc.checkReady();
 });

--- a/e2e/user/user-can-edit-account.spec.ts
+++ b/e2e/user/user-can-edit-account.spec.ts
@@ -21,9 +21,9 @@ test("user can register, edit account details, save, and should see their detail
   const pgEditMyAccount = new UserMyAccountEditPage(context);
 
   // Navigate to My Accounts
-  await pgPets.checkUrl();
+  await pgPets.checkReady();
   await nav.myAcountOption().click();
-  await pgMyAccount.checkUrl();
+  await pgMyAccount.checkReady();
 
   // Check existing details
   await expect(pgMyAccount.exactText(userName)).toBeVisible();
@@ -33,14 +33,14 @@ test("user can register, edit account details, save, and should see their detail
 
   // WHEN user navigates to edit page, and saves
   await pgMyAccount.editButton().click();
-  await pgEditMyAccount.checkUrl();
+  await pgEditMyAccount.checkReady();
   await pgEditMyAccount.userNameField().fill("New Name");
   await pgEditMyAccount.userPhoneNumberField().fill("+65 12345678");
   await pgEditMyAccount.userResidencyOption_OTHERS().click();
   await pgEditMyAccount.saveButton().click();
 
   // THEN
-  await pgMyAccount.checkUrl();
+  await pgMyAccount.checkReady();
   await expect(pgMyAccount.exactText("New Name")).toBeVisible();
   await expect(pgMyAccount.residencyItem()).toHaveValue("Other");
   await expect(pgMyAccount.emailItem()).toHaveValue(userEmail);

--- a/e2e/user/user-can-edit-dog.spec.ts
+++ b/e2e/user/user-can-edit-dog.spec.ts
@@ -19,12 +19,12 @@ test("user can edit dog profile", async ({ page }) => {
   // Navigate to Edit Page
   await pgList.checkReady();
   await pgList.dogCardItem(dogName).locator().click();
-  await pgView.checkUrl();
+  await pgView.checkReady();
   await pgView.editButton().click();
-  await pgEdit.checkUrl();
+  await pgEdit.checkReady();
 
   // Fill in the Edit Dog form
-  await pgEdit.checkUrl();
+  await pgEdit.checkReady();
   await expect(pgEdit.dogNameField()).toHaveValue(dogName);
   await expect(pgEdit.dogBreedField()).toHaveValue(dogBreed);
   await expect(pgEdit.dogBirthdayField()).toHaveValue(dogBirthday);
@@ -51,11 +51,11 @@ test("user can edit dog profile", async ({ page }) => {
   ).not.toBeVisible();
 
   // Should be back at the view dog page.
-  await pgView.checkUrl();
+  await pgView.checkReady();
 
   // Go back to edit page to verify changes.
   await pgView.editButton().click();
-  await pgEdit.checkUrl();
+  await pgEdit.checkReady();
   await expect(pgEdit.dogNameField()).toHaveValue("Thomas Green");
   await expect(pgEdit.dogBreedField()).toHaveValue("Royal Canine");
   await expect(pgEdit.dogBirthdayField()).toHaveValue("28 Aug 1968");

--- a/e2e/user/user-can-edit-dog.spec.ts
+++ b/e2e/user/user-can-edit-dog.spec.ts
@@ -17,7 +17,7 @@ test("user can edit dog profile", async ({ page }) => {
   const pgEdit = new UserEditDogPage(context);
 
   // Navigate to Edit Page
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await pgList.dogCardItem(dogName).locator().click();
   await pgView.checkUrl();
   await pgView.editButton().click();

--- a/e2e/user/user-can-edit-incomplete-dog.spec.ts
+++ b/e2e/user/user-can-edit-incomplete-dog.spec.ts
@@ -28,7 +28,7 @@ test("user can edit incomplete dog profile", async ({ page }) => {
   await pgList.checkReady();
   await pgList.dogCardItem(dogName).locator().click();
   await pgView.editButton().click();
-  await pgEdit.checkUrl();
+  await pgEdit.checkReady();
 
   // Complete the profile
   await pgEdit.dogEverReceivedTransfusionOption_NO().click();
@@ -38,7 +38,7 @@ test("user can edit incomplete dog profile", async ({ page }) => {
   await toast.closeButton().click();
 
   // Navigate back to list
-  await pgView.checkUrl();
+  await pgView.checkReady();
   await pgView.backButton().click();
   await pgList.checkReady();
 

--- a/e2e/user/user-can-edit-incomplete-dog.spec.ts
+++ b/e2e/user/user-can-edit-incomplete-dog.spec.ts
@@ -19,13 +19,13 @@ test("user can edit incomplete dog profile", async ({ page }) => {
 
   // Starting at the dog list page, user should see that their dog's profile is
   // incomplete.
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await expect(
     pgList.dogCardItem(dogName).profileIncompleteStatusText(),
   ).toBeVisible();
 
   // Navigate to edit dog form
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await pgList.dogCardItem(dogName).locator().click();
   await pgView.editButton().click();
   await pgEdit.checkUrl();
@@ -40,7 +40,7 @@ test("user can edit incomplete dog profile", async ({ page }) => {
   // Navigate back to list
   await pgView.checkUrl();
   await pgView.backButton().click();
-  await pgList.checkUrl();
+  await pgList.checkReady();
 
   // Verify status is updated
   await expect(

--- a/e2e/user/user-can-set-weight-to-empty.spec.ts
+++ b/e2e/user/user-can-set-weight-to-empty.spec.ts
@@ -18,7 +18,7 @@ test("user can set weight to empty", async ({ page }) => {
   const toast = new ToastComponent(context);
 
   // Navigate to Edit Page
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await pgList.dogCardItem(dogName).locator().click();
   await pgView.checkUrl();
   await pgView.editButton().click();

--- a/e2e/user/user-can-set-weight-to-empty.spec.ts
+++ b/e2e/user/user-can-set-weight-to-empty.spec.ts
@@ -20,22 +20,22 @@ test("user can set weight to empty", async ({ page }) => {
   // Navigate to Edit Page
   await pgList.checkReady();
   await pgList.dogCardItem(dogName).locator().click();
-  await pgView.checkUrl();
+  await pgView.checkReady();
   await pgView.editButton().click();
-  await pgEdit.checkUrl();
+  await pgEdit.checkReady();
 
   // Fill in the Edit Dog form
-  await pgEdit.checkUrl();
+  await pgEdit.checkReady();
   await pgEdit.dogWeightField().fill("");
   await pgEdit.saveButton().click();
   await expect(toast.locator()).toContainText("Saved");
   await toast.closeButton().click();
 
   // Should be back at the view dog page.
-  await pgView.checkUrl();
+  await pgView.checkReady();
 
   // Go back to edit page to verify changes.
   await pgView.editButton().click();
-  await pgEdit.checkUrl();
+  await pgEdit.checkReady();
   await expect(pgEdit.dogWeightField()).toHaveValue("");
 });

--- a/e2e/user/user-can-view-account.spec.ts
+++ b/e2e/user/user-can-view-account.spec.ts
@@ -13,9 +13,9 @@ test("user can view their account", async ({ page }) => {
   const pgMyPets = new UserMyPetsPage(context);
   const pgAccount = new UserMyAccountPage(context);
 
-  await pgMyPets.checkUrl();
+  await pgMyPets.checkReady();
   await nav.myAcountOption().click();
-  await pgAccount.checkUrl();
+  await pgAccount.checkReady();
 
   const { userName, userEmail, userPhoneNumber, userResidency } = knownUser;
   await expect(pgAccount.exactText(userName)).toBeVisible();

--- a/e2e/user/user-can-view-dog.spec.ts
+++ b/e2e/user/user-can-view-dog.spec.ts
@@ -14,7 +14,7 @@ test("user can view dog", async ({ page }) => {
   const pgList = new UserMyPetsPage(context);
   const pgView = new UserViewDogPage(context);
 
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await pgList.dogCardItem(dogName).locator().click();
 
   await pgView.checkUrl();

--- a/e2e/user/user-can-view-dog.spec.ts
+++ b/e2e/user/user-can-view-dog.spec.ts
@@ -17,7 +17,7 @@ test("user can view dog", async ({ page }) => {
   await pgList.checkReady();
   await pgList.dogCardItem(dogName).locator().click();
 
-  await pgView.checkUrl();
+  await pgView.checkReady();
   await expect(
     pgView.page().getByRole("heading", { name: dogName }),
   ).toBeVisible();

--- a/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
+++ b/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
@@ -66,12 +66,12 @@ test("user can view report and edit sub-profile", async ({
   // registration dog weight is the most recent.
   await pgPets.checkReady();
   await pgPets.dogCardItem(dogName).locator().click();
-  await pgViewDog.checkUrl();
+  await pgViewDog.checkReady();
   await expect(pgViewDog.dogWeightItem()).toContainText(registeredDogWeightKg);
 
   // View the report and verify it has the reported weight, and other fields.
   await pgViewDog.getReportItem({ visitTime, vetName }).click();
-  await pgViewReport.checkUrl();
+  await pgViewReport.checkReady();
   await expect(pgViewReport.dogWeightItem()).toContainText(reportedDogWeightKg);
   await expect(pgViewReport.dogBreedItem()).toContainText(dogBreed);
 
@@ -80,9 +80,9 @@ test("user can view report and edit sub-profile", async ({
   const newName = "Molly Briggs";
   const newWeight = "333";
   await pgViewReport.backButton().click();
-  await pgViewDog.checkUrl();
+  await pgViewDog.checkReady();
   await pgViewDog.editButton().click();
-  await pgEdit.checkUrl();
+  await pgEdit.checkReady();
   await expect(pgEdit.evidenceThisIsTheSubProfileForm()).toBeVisible();
   await pgEdit.dogNameField().fill(newName);
   await pgEdit.dogEverReceivedTransfusionOption(YES_NO.YES).click();
@@ -92,7 +92,7 @@ test("user can view report and edit sub-profile", async ({
   await toast.closeButton().click();
 
   // Verify the edits, we should be in the view dog page again.
-  await pgViewDog.checkUrl();
+  await pgViewDog.checkReady();
   await expect(pgViewDog.dogNameHeader(newName)).toBeVisible();
   await expect(pgViewDog.dogWeightItem()).toContainText(newWeight);
   await expect(pgViewDog.dogEverReceivedTransfusionItem()).toContainText(

--- a/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
+++ b/e2e/user/user-can-view-report-and-edit-sub-profile.spec.ts
@@ -64,7 +64,7 @@ test("user can view report and edit sub-profile", async ({
 
   // Verify that dog's weight is the registration dog weight, because
   // registration dog weight is the most recent.
-  await pgPets.checkUrl();
+  await pgPets.checkReady();
   await pgPets.dogCardItem(dogName).locator().click();
   await pgViewDog.checkUrl();
   await expect(pgViewDog.dogWeightItem()).toContainText(registeredDogWeightKg);

--- a/e2e/user/user-can-view-then-edit-dog.ts
+++ b/e2e/user/user-can-view-then-edit-dog.ts
@@ -21,21 +21,21 @@ test("user can list, view, edit, cancel, edit, submit, back, list", async ({
   await myPetsPage.checkReady();
   await myPetsPage.dogCardItem(dogName).locator().click();
 
-  await viewDogPage.checkUrl();
+  await viewDogPage.checkReady();
   await viewDogPage.editButton().click();
 
-  await editDogPage.checkUrl();
+  await editDogPage.checkReady();
   await editDogPage.cancelButton().click();
 
-  await viewDogPage.checkUrl();
+  await viewDogPage.checkReady();
   await viewDogPage.editButton().click();
 
-  await editDogPage.checkUrl();
+  await editDogPage.checkReady();
   await editDogPage.saveButton().click();
   await expect(toast.locator()).toContainText("Saved");
   await toast.closeButton().click();
 
-  await viewDogPage.checkUrl();
+  await viewDogPage.checkReady();
   await viewDogPage.backButton().click();
 
   await myPetsPage.checkReady();

--- a/e2e/user/user-can-view-then-edit-dog.ts
+++ b/e2e/user/user-can-view-then-edit-dog.ts
@@ -18,7 +18,7 @@ test("user can list, view, edit, cancel, edit, submit, back, list", async ({
   const viewDogPage = new UserViewDogPage(context);
   const toast = new ToastComponent(context);
 
-  await myPetsPage.checkUrl();
+  await myPetsPage.checkReady();
   await myPetsPage.dogCardItem(dogName).locator().click();
 
   await viewDogPage.checkUrl();
@@ -38,5 +38,5 @@ test("user can list, view, edit, cancel, edit, submit, back, list", async ({
   await viewDogPage.checkUrl();
   await viewDogPage.backButton().click();
 
-  await myPetsPage.checkUrl();
+  await myPetsPage.checkReady();
 });

--- a/e2e/user/user-login-page-validations.spec.ts
+++ b/e2e/user/user-login-page-validations.spec.ts
@@ -7,7 +7,7 @@ import { UserMyPetsPage } from "../_lib/pom/pages/user-my-pets-page";
 test("email cannot be empty when requesting an otp", async ({ page }) => {
   const context = await initPomContext({ page });
   const pg = new UserLoginPage(context);
-  await pg.checkUrl();
+  await pg.checkReady();
   await pg.sendMeAnOtpButton().click();
   await expect(pg.invalidEmailErrorMessage()).toBeVisible();
 });
@@ -15,7 +15,7 @@ test("email cannot be empty when requesting an otp", async ({ page }) => {
 test("email cannot be invalid when requesting an otp", async ({ page }) => {
   const context = await initPomContext({ page });
   const pg = new UserLoginPage(context);
-  await pg.checkUrl();
+  await pg.checkReady();
   await pg.emailField().fill("invalid_email_value");
   await pg.sendMeAnOtpButton().click();
   await expect(pg.invalidEmailErrorMessage()).toBeVisible();
@@ -26,7 +26,7 @@ test("email must belong to an account when requesting an otp", async ({
 }) => {
   const context = await initPomContext({ page });
   const pg = new UserLoginPage(context);
-  await pg.checkUrl();
+  await pg.checkReady();
   await pg.emailField().fill("no_account@user.com");
   await pg.sendMeAnOtpButton().click();
   await expect(pg.userAccountDoesNotExistErrorMessage()).toBeVisible();
@@ -37,7 +37,7 @@ test("shows otp sent when requesting an otp for a valid email", async ({
 }) => {
   const context = await initPomContext({ page });
   const pg = new UserLoginPage(context);
-  await pg.checkUrl();
+  await pg.checkReady();
   const { userEmail } = getKnownUser();
   await pg.emailField().fill(userEmail);
   await pg.sendMeAnOtpButton().click();
@@ -47,7 +47,7 @@ test("shows otp sent when requesting an otp for a valid email", async ({
 test("otp cannot be empty when login is clicked", async ({ page }) => {
   const context = await initPomContext({ page });
   const pg = new UserLoginPage(context);
-  await pg.checkUrl();
+  await pg.checkReady();
   const { userEmail } = getKnownUser();
   await pg.emailField().fill(userEmail);
   await pg.sendMeAnOtpButton().click();

--- a/e2e/vet/call-task-uses-latest-values.spec.ts
+++ b/e2e/vet/call-task-uses-latest-values.spec.ts
@@ -30,7 +30,7 @@ test("call task uses latest values", async ({ page, request }) => {
   const sidebar = new NavComponent(context);
   const toast = new ToastComponent(context);
 
-  await pgSchedule.checkUrl();
+  await pgSchedule.checkReady();
   await pgSchedule.dogCard(dogName).locator().click();
   const isMobile = await doGetIsMobile(context);
   const activityArea = isMobile
@@ -41,7 +41,7 @@ test("call task uses latest values", async ({ page, request }) => {
 
   await sidebar.vetAppointmentsOption().click();
 
-  await pgAppointments.checkUrl();
+  await pgAppointments.checkReady();
   await pgAppointments
     .appointmentCard({ dogName })
     .submitReportButton()
@@ -75,9 +75,9 @@ test("call task uses latest values", async ({ page, request }) => {
   await expect(toast.locator()).toContainText("Submitted");
   await toast.closeButton().click();
 
-  await pgAppointments.checkUrl();
+  await pgAppointments.checkReady();
   await sidebar.vetScheduleOption().click();
-  await pgSchedule.checkUrl();
+  await pgSchedule.checkReady();
 
   await expect(pgSchedule.dogCard(dogName).locator()).toBeVisible();
   await expect(pgSchedule.dogCard(dogName).locator()).toContainText(newWeight);

--- a/e2e/vet/call-task-uses-latest-values.spec.ts
+++ b/e2e/vet/call-task-uses-latest-values.spec.ts
@@ -46,7 +46,7 @@ test("call task uses latest values", async ({ page, request }) => {
     .appointmentCard({ dogName })
     .submitReportButton()
     .click();
-  await pgSubmit.checkUrl();
+  await pgSubmit.checkReady();
 
   // For this test to work, the profile modification time needs to be before the
   // visit date. However, since profile modification time is set by

--- a/e2e/vet/vet-can-cancel-appointment.spec.ts
+++ b/e2e/vet/vet-can-cancel-appointment.spec.ts
@@ -14,7 +14,7 @@ test("vet can cancel appointment", async ({ page }) => {
   await pg1.appointmentCard({ dogName }).cancelAppointmentButton().click();
 
   const pg2 = new VetAppointmentCancelPage(context);
-  await pg2.checkUrl();
+  await pg2.checkReady();
   await pg2.confirmButton().click();
 
   const pg3 = new VetAppointmentListPage(context);

--- a/e2e/vet/vet-can-cancel-appointment.spec.ts
+++ b/e2e/vet/vet-can-cancel-appointment.spec.ts
@@ -9,7 +9,7 @@ test("vet can cancel appointment", async ({ page }) => {
   const { dogName } = await doCreateAppointment(context);
 
   const pg1 = new VetAppointmentListPage(context);
-  await pg1.checkUrl();
+  await pg1.checkReady();
   await expect(pg1.appointmentCard({ dogName }).locator()).toBeVisible();
   await pg1.appointmentCard({ dogName }).cancelAppointmentButton().click();
 
@@ -18,6 +18,6 @@ test("vet can cancel appointment", async ({ page }) => {
   await pg2.confirmButton().click();
 
   const pg3 = new VetAppointmentListPage(context);
-  await pg3.checkUrl();
+  await pg3.checkReady();
   await expect(pg3.appointmentCard({ dogName }).locator()).not.toBeVisible();
 });

--- a/e2e/vet/vet-can-edit-report.spec.ts
+++ b/e2e/vet/vet-can-edit-report.spec.ts
@@ -10,7 +10,8 @@ import { VetReportEditPage } from "../_lib/pom/pages/vet-report-edit-page";
 import { VetReportViewPage } from "../_lib/pom/pages/vet-report-view-page";
 import { ToastComponent } from "../_lib/pom/layout/toast-component";
 
-test("vet can edit report", async ({ page }) => {
+test("vet can edit report", async ({ page }, testInfo) => {
+  testInfo.setTimeout(60000);
   const context = await initPomContext({ page });
   const { dogName } = await givenSubmittedReport(context);
 

--- a/e2e/vet/vet-can-edit-report.spec.ts
+++ b/e2e/vet/vet-can-edit-report.spec.ts
@@ -48,7 +48,7 @@ async function givenSubmittedReport(context: PomContext): Promise<{
   await pgList.checkReady();
   await pgList.appointmentCard({ dogName }).submitReportButton().click();
 
-  await pgSubmit.checkUrl();
+  await pgSubmit.checkReady();
   await expect(pgSubmit.submitButton()).toBeVisible();
   await pgSubmit.visitDateField().fill("6 May 2024");
   await pgSubmit.dogWeightField().fill("27.89");
@@ -84,9 +84,9 @@ async function changeBloodTypeToNegative(
 
   await pgList.checkReady();
   await pgList.reportCard({ dogName }).locator().click();
-  await pgView.checkUrl();
+  await pgView.checkReady();
   await pgView.editButton().click();
-  await pgEdit.checkUrl();
+  await pgEdit.checkReady();
   await expect(pgEdit.submitButton()).toBeVisible();
 
   await pgEdit.dogDea1Point1_NEGATIVE().click();
@@ -94,7 +94,7 @@ async function changeBloodTypeToNegative(
   await expect(toast.locator()).toContainText("Saved");
   await toast.closeButton().click();
 
-  await pgView.checkUrl();
+  await pgView.checkReady();
   await expect(pgView.backButton()).toBeVisible();
   await pgView.backButton().click();
   await pgList.checkReady();

--- a/e2e/vet/vet-can-edit-report.spec.ts
+++ b/e2e/vet/vet-can-edit-report.spec.ts
@@ -17,7 +17,7 @@ test("vet can edit report", async ({ page }) => {
   const pgList = new VetReportListPage(context);
 
   // Should be DEA1.1 Positive at first
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await expect(pgList.reportCard({ dogName }).locator()).toBeVisible();
   await expect(
     pgList.reportCard({ dogName }).dea1Point1PositiveBadge(),
@@ -27,7 +27,7 @@ test("vet can edit report", async ({ page }) => {
   await changeBloodTypeToNegative(context, { dogName });
 
   // Should now be DEA1.1 Negative
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await expect(pgList.reportCard({ dogName }).locator()).toBeVisible();
   await expect(
     pgList.reportCard({ dogName }).dea1Point1NegativeBadge(),
@@ -45,7 +45,7 @@ async function givenSubmittedReport(context: PomContext): Promise<{
   const pgReportList = new VetReportListPage(context);
   const toast = new ToastComponent(context);
 
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await pgList.appointmentCard({ dogName }).submitReportButton().click();
 
   await pgSubmit.checkUrl();
@@ -61,12 +61,12 @@ async function givenSubmittedReport(context: PomContext): Promise<{
   await expect(toast.locator()).toContainText("Submitted");
   await toast.closeButton().click();
 
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await expect(pgList.appointmentCard({ dogName }).locator()).not.toBeVisible();
 
   await sideBarOrDock.vetReportsOption().click();
 
-  await pgReportList.checkUrl();
+  await pgReportList.checkReady();
   await expect(pgReportList.reportCard({ dogName }).locator()).toBeVisible();
   return { dogName };
 }
@@ -82,7 +82,7 @@ async function changeBloodTypeToNegative(
   const pgEdit = new VetReportEditPage(context);
   const toast = new ToastComponent(context);
 
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await pgList.reportCard({ dogName }).locator().click();
   await pgView.checkUrl();
   await pgView.editButton().click();
@@ -97,5 +97,5 @@ async function changeBloodTypeToNegative(
   await pgView.checkUrl();
   await expect(pgView.backButton()).toBeVisible();
   await pgView.backButton().click();
-  await pgList.checkUrl();
+  await pgList.checkReady();
 }

--- a/e2e/vet/vet-can-record-appointment-call-outcome.spec.ts
+++ b/e2e/vet/vet-can-record-appointment-call-outcome.spec.ts
@@ -16,7 +16,7 @@ test("vet can record APPOINTMENT call outcome", async ({ page }) => {
   await doLogoutSequence(context);
   await doLoginKnownVet(context);
   const pg1 = new VetSchedulePage(context);
-  await pg1.checkUrl();
+  await pg1.checkReady();
   await expect(pg1.dogCard(dogName).locator()).toBeVisible();
 
   await pg1.dogCard(dogName).locator().click();

--- a/e2e/vet/vet-can-record-declined-call-outcome.spec.ts
+++ b/e2e/vet/vet-can-record-declined-call-outcome.spec.ts
@@ -16,7 +16,7 @@ test("vet can record DECLINED call outcome", async ({ page }) => {
   await doLogoutSequence(context);
   await doLoginKnownVet(context);
   const pg1 = new VetSchedulePage(context);
-  await pg1.checkUrl();
+  await pg1.checkReady();
   await expect(pg1.dogCard(dogName).locator()).toBeVisible();
 
   await pg1.dogCard(dogName).locator().click();

--- a/e2e/vet/vet-can-submit-report.spec.ts
+++ b/e2e/vet/vet-can-submit-report.spec.ts
@@ -20,7 +20,7 @@ test("vet can submit report", async ({ page }) => {
   await pgList.checkReady();
   await pgList.appointmentCard({ dogName }).submitReportButton().click();
 
-  await pgSubmit.checkUrl();
+  await pgSubmit.checkReady();
   await expect(pgSubmit.submitButton()).toBeVisible();
   await pgSubmit.visitDateField().fill("11 May 2024");
   await pgSubmit.dogWeightField().fill("28.61");

--- a/e2e/vet/vet-can-submit-report.spec.ts
+++ b/e2e/vet/vet-can-submit-report.spec.ts
@@ -17,7 +17,7 @@ test("vet can submit report", async ({ page }) => {
   const nav = new NavComponent(context);
   const pgReportList = new VetReportListPage(context);
 
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await pgList.appointmentCard({ dogName }).submitReportButton().click();
 
   await pgSubmit.checkUrl();
@@ -33,7 +33,7 @@ test("vet can submit report", async ({ page }) => {
   await expect(toast.locator()).toContainText("Submitted");
   await toast.closeButton().click();
 
-  await pgList.checkUrl();
+  await pgList.checkReady();
   await expect(pgList.appointmentCard({ dogName }).locator()).not.toBeVisible();
 
   await nav.vetReportsOption().click();

--- a/e2e/vet/vet-can-view-report.spec.ts
+++ b/e2e/vet/vet-can-view-report.spec.ts
@@ -8,7 +8,8 @@ import { VetReportListPage } from "../_lib/pom/pages/vet-report-list-page";
 import { VetReportViewPage } from "../_lib/pom/pages/vet-report-view-page";
 import { ToastComponent } from "../_lib/pom/layout/toast-component";
 
-test("vet can view report", async ({ page }) => {
+test("vet can view report", async ({ page }, testInfo) => {
+  testInfo.setTimeout(60000);
   const context = await initPomContext({ page });
   const { dogName } = await doCreateAppointment(context);
 

--- a/e2e/vet/vet-can-view-report.spec.ts
+++ b/e2e/vet/vet-can-view-report.spec.ts
@@ -25,7 +25,7 @@ test("vet can view report", async ({ page }) => {
     .appointmentCard({ dogName })
     .submitReportButton()
     .click();
-  await pgSubmit.checkUrl();
+  await pgSubmit.checkReady();
   await pgSubmit.visitDateField().fill("13 Jan 2021");
   await pgSubmit.dogWeightField().fill("42.5");
   await pgSubmit.dogBcsSelector().click();
@@ -46,10 +46,10 @@ test("vet can view report", async ({ page }) => {
   await sideBarOrDock.vetReportsOption().click();
   await pgReportList.checkReady();
   await pgReportList.reportCard({ dogName }).locator().click();
-  await pgView.checkUrl();
+  await pgView.checkReady();
 
   // Check values
-  await pgView.checkUrl();
+  await pgView.checkReady();
   await expect(
     pgView.field("Visit Date").getByText("13 Jan 2021", { exact: true }),
   ).toBeVisible();

--- a/e2e/vet/vet-can-view-report.spec.ts
+++ b/e2e/vet/vet-can-view-report.spec.ts
@@ -20,7 +20,7 @@ test("vet can view report", async ({ page }) => {
   const toast = new ToastComponent(context);
 
   // Submit a report
-  await pgAppointmentList.checkUrl();
+  await pgAppointmentList.checkReady();
   await pgAppointmentList
     .appointmentCard({ dogName })
     .submitReportButton()
@@ -39,12 +39,12 @@ test("vet can view report", async ({ page }) => {
   await pgSubmit.submitButton().click();
   await expect(toast.locator()).toContainText("Submitted");
   await toast.closeButton().click();
-  await pgAppointmentList.checkUrl();
+  await pgAppointmentList.checkReady();
 
   // Navigate to view report page
-  await pgAppointmentList.checkUrl();
+  await pgAppointmentList.checkReady();
   await sideBarOrDock.vetReportsOption().click();
-  await pgReportList.checkUrl();
+  await pgReportList.checkReady();
   await pgReportList.reportCard({ dogName }).locator().click();
   await pgView.checkUrl();
 

--- a/e2e/visitor/visitor-can-register-without-preferred-vet.spec.ts
+++ b/e2e/visitor/visitor-can-register-without-preferred-vet.spec.ts
@@ -14,6 +14,6 @@ test("visitor can register without a preferred vet", async ({ page }) => {
   } = await doRegister(context, { withoutPreferredVet: true });
   await pgPets.checkReady();
   await pgPets.dogCardItem(dogName).locator().click();
-  await pgView.checkUrl();
+  await pgView.checkReady();
   await expect(pgView.dogPreferredVetItem()).toContainText("No preferred vet");
 });

--- a/e2e/visitor/visitor-can-register-without-preferred-vet.spec.ts
+++ b/e2e/visitor/visitor-can-register-without-preferred-vet.spec.ts
@@ -12,7 +12,7 @@ test("visitor can register without a preferred vet", async ({ page }) => {
   const {
     dog: { dogName },
   } = await doRegister(context, { withoutPreferredVet: true });
-  await pgPets.checkUrl();
+  await pgPets.checkReady();
   await pgPets.dogCardItem(dogName).locator().click();
   await pgView.checkUrl();
   await expect(pgView.dogPreferredVetItem()).toContainText("No preferred vet");

--- a/e2e/visitor/visitor-can-register.spec.ts
+++ b/e2e/visitor/visitor-can-register.spec.ts
@@ -12,12 +12,12 @@ test("visitor can register a new user account", async ({ page }) => {
   // Navigating to the registration form
   const context = await initPomContext({ page });
   const pg1 = new UserLoginPage(context);
-  await pg1.checkUrl();
+  await pg1.checkReady();
   await pg1.registerLink().click();
 
   // Fill in the dog form
   const pg2 = new UserRegistrationPage(context);
-  await pg2.checkUrl();
+  await pg2.checkReady();
   await expect(pg2.dogFormHeader()).toBeVisible();
   await pg2.dogNameField().fill("Casper");
   await pg2.dogBreedField().fill("White Sheet Dog");
@@ -60,7 +60,7 @@ test("visitor can register a new user account", async ({ page }) => {
 
   // Check for expected dog in my pets
   const pg3 = new UserMyPetsPage(context);
-  await pg3.checkUrl();
+  await pg3.checkReady();
   await expect(pg3.dogCardItem("Casper").locator()).toBeVisible();
 
   // Navigate to my account page
@@ -70,7 +70,7 @@ test("visitor can register a new user account", async ({ page }) => {
 
   // Check for account details
   const pg4 = new UserMyAccountPage(context);
-  await pg4.checkUrl();
+  await pg4.checkReady();
   await expect(pg4.exactText("Ian Little")).toBeVisible();
   await expect(pg4.residencyItem()).toHaveValue("Singapore");
   await expect(pg4.phoneNumberItem()).toHaveValue("87654321");

--- a/scripts/make-ticket.sh
+++ b/scripts/make-ticket.sh
@@ -2,8 +2,8 @@
 
 # Generate a BARK-? branch name
 
-branchName="BARK-$((RANDOM % 10000))"
+branchName=$(printf "BARK-%04d" $((RANDOM % 10000)))
 while [ -n "$(git log --oneline --all | grep $branchName)" ]; do
-    branchName="BARK-$((RANDOM % 10000))"
+    branchName=$(printf "BARK-%04d" $((RANDOM % 10000)))
 done
 echo $branchName

--- a/scripts/make-ticket.sh
+++ b/scripts/make-ticket.sh
@@ -2,8 +2,9 @@
 
 # Generate a BARK-? branch name
 
-branchName=$(printf "BARK-%04d" $((RANDOM % 10000)))
-while [ -n "$(git log --oneline --all | grep $branchName)" ]; do
-    branchName=$(printf "BARK-%04d" $((RANDOM % 10000)))
+modBase=100
+branchName=$(printf "BARK-%d" $((RANDOM % $modBase)))
+while [ -n "$(git log --oneline --all | grep $branchName\\b)" ]; do
+    branchName=$(printf "BARK-%d" $((RANDOM % $modBase)))
 done
 echo $branchName


### PR DESCRIPTION
(1) Recently UI tests have been flaky we addressed this with two different approaches.

(i) We increased the timeout of some slow tests to 1 minutes.

(ii) We introduced a way for pages to define how to checkPageLoaded. Since approach (i) resolved the issues, we only used checkPagePayload for a few pages. Nevertheless, the feature is available for future tests.
