### PR TITLE
BARK-35: Injectable ReportDao

### DIFF
--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -607,8 +607,7 @@ export class AppFactory {
   public getReportDao(): Promise<ReportDao> {
     if (this.promisedReportDao === null) {
       this.promisedReportDao = new Promise(async (resolve) => {
-        const dbPool = await this.getDbPool();
-        const dao = new ReportDao({ dbPool });
+        const dao = new ReportDao();
         this.logCreated("ReportDao");
         resolve(dao);
       });

--- a/src/lib/app.ts
+++ b/src/lib/app.ts
@@ -61,6 +61,7 @@ import { PawtalEventService } from "./bark/services/pawtal-event-service";
 import { opIndexDonorSnapshots } from "./bark/operations/op-index-donor-snapshots";
 import { AdminAccountService } from "./bark/services/admin-account-service";
 import { DogProfileService } from "./bark/services/dog-profile-service";
+import { ReportDao } from "./bark/daos/report-dao";
 
 export class AppFactory {
   private envs: NodeJS.Dict<string>;
@@ -93,6 +94,7 @@ export class AppFactory {
   private promisedPawtalEventService: Promise<PawtalEventService> | null = null;
   private promisedAdminAccountService: Promise<AdminAccountService> | null =
     null;
+  private promisedReportDao: Promise<ReportDao> | null = null;
 
   constructor(envs: NodeJS.Dict<string>) {
     this.envs = envs;
@@ -593,12 +595,25 @@ export class AppFactory {
     if (this.promisedDogProfileService === null) {
       this.promisedDogProfileService = new Promise(async (resolve) => {
         const context = await this.getBarkContext();
-        const service = new DogProfileService({ context });
+        const reportDao = await this.getReportDao();
+        const service = new DogProfileService({ context, reportDao });
         this.logCreated("DogProfileService");
         resolve(service);
       });
     }
     return this.promisedDogProfileService;
+  }
+
+  public getReportDao(): Promise<ReportDao> {
+    if (this.promisedReportDao === null) {
+      this.promisedReportDao = new Promise(async (resolve) => {
+        const dbPool = await this.getDbPool();
+        const dao = new ReportDao({ dbPool });
+        this.logCreated("ReportDao");
+        resolve(dao);
+      });
+    }
+    return this.promisedReportDao;
   }
 
   public getUserMapper(): Promise<UserMapper> {

--- a/src/lib/bark/daos/report-dao.ts
+++ b/src/lib/bark/daos/report-dao.ts
@@ -1,4 +1,4 @@
-import { DbConnection, DbContext, DbPool, dbQuery } from "@/lib/data/db-utils";
+import { DbContext, dbQuery } from "@/lib/data/db-utils";
 import { z } from "zod";
 import {
   EncryptedBarkReport,

--- a/src/lib/bark/operations/op-edit-report.ts
+++ b/src/lib/bark/operations/op-edit-report.ts
@@ -16,7 +16,7 @@ export async function opEditReport(
 > {
   const { dbPool } = context;
   const { reportId, reportData, actorVetId } = args;
-  const reportDao = new ReportDao({ dbPool });
+  const reportDao = new ReportDao();
   const conn = await dbPool.connect();
   try {
     const encryptedReportData = await toEncryptedBarkReportData(
@@ -25,7 +25,7 @@ export async function opEditReport(
     );
 
     await dbBegin(conn);
-    const metadata = await reportDao.getMetadata({ reportId, conn });
+    const metadata = await reportDao.getMetadata({ reportId, db: conn });
     if (metadata === null) {
       return CODE.ERROR_REPORT_NOT_FOUND;
     }
@@ -35,7 +35,7 @@ export async function opEditReport(
     const didUpdate = await reportDao.update({
       reportId,
       spec: encryptedReportData,
-      conn,
+      db: conn,
     });
     if (!didUpdate) {
       return CODE.ERROR_REPORT_NOT_FOUND;

--- a/src/lib/bark/operations/op-edit-report.ts
+++ b/src/lib/bark/operations/op-edit-report.ts
@@ -16,6 +16,7 @@ export async function opEditReport(
 > {
   const { dbPool } = context;
   const { reportId, reportData, actorVetId } = args;
+  const reportDao = new ReportDao({ dbPool });
   const conn = await dbPool.connect();
   try {
     const encryptedReportData = await toEncryptedBarkReportData(
@@ -24,8 +25,7 @@ export async function opEditReport(
     );
 
     await dbBegin(conn);
-    const reportDao = new ReportDao(conn);
-    const metadata = await reportDao.getMetadata({ reportId });
+    const metadata = await reportDao.getMetadata({ reportId, conn });
     if (metadata === null) {
       return CODE.ERROR_REPORT_NOT_FOUND;
     }
@@ -35,6 +35,7 @@ export async function opEditReport(
     const didUpdate = await reportDao.update({
       reportId,
       spec: encryptedReportData,
+      conn,
     });
     if (!didUpdate) {
       return CODE.ERROR_REPORT_NOT_FOUND;

--- a/src/lib/bark/operations/op-fetch-report.ts
+++ b/src/lib/bark/operations/op-fetch-report.ts
@@ -24,11 +24,12 @@ export async function opFetchReport(
 > {
   const { dbPool } = context;
   const { reportId, actorVetId, actorUserId } = args;
+  const reportDao = new ReportDao({ dbPool });
   const conn = await dbPool.connect();
   try {
-    const reportDao = new ReportDao(conn);
     const encryptedReport = await reportDao.getEncryptedBarkReport({
       reportId,
+      conn,
     });
     if (encryptedReport === null) {
       return Err(CODE.ERROR_REPORT_NOT_FOUND);

--- a/src/lib/bark/operations/op-fetch-report.ts
+++ b/src/lib/bark/operations/op-fetch-report.ts
@@ -24,12 +24,12 @@ export async function opFetchReport(
 > {
   const { dbPool } = context;
   const { reportId, actorVetId, actorUserId } = args;
-  const reportDao = new ReportDao({ dbPool });
+  const reportDao = new ReportDao();
   const conn = await dbPool.connect();
   try {
     const encryptedReport = await reportDao.getEncryptedBarkReport({
       reportId,
-      conn,
+      db: conn,
     });
     if (encryptedReport === null) {
       return Err(CODE.ERROR_REPORT_NOT_FOUND);

--- a/src/lib/bark/operations/op-fetch-reports-by-vet-id.ts
+++ b/src/lib/bark/operations/op-fetch-reports-by-vet-id.ts
@@ -12,7 +12,7 @@ export async function opFetchReportsByVetId(
   const { dbPool } = context;
   const { vetId } = args;
   try {
-    const dao = new ReportDao(dbPool);
+    const dao = new ReportDao({ dbPool });
     const encryptedReports = await dao.getEncryptedBarkReportsByVetId({
       vetId,
     });

--- a/src/lib/bark/operations/op-fetch-reports-by-vet-id.ts
+++ b/src/lib/bark/operations/op-fetch-reports-by-vet-id.ts
@@ -12,9 +12,10 @@ export async function opFetchReportsByVetId(
   const { dbPool } = context;
   const { vetId } = args;
   try {
-    const dao = new ReportDao({ dbPool });
+    const dao = new ReportDao();
     const encryptedReports = await dao.getEncryptedBarkReportsByVetId({
       vetId,
+      db: dbPool,
     });
     const futureReports = encryptedReports.map(async (encryptedReport) =>
       toBarkReport(context, encryptedReport),

--- a/src/lib/bark/operations/op-submit-report.ts
+++ b/src/lib/bark/operations/op-submit-report.ts
@@ -32,6 +32,7 @@ export async function opSubmitReport(
 > {
   const { dbPool } = context;
   const { appointmentId, reportData, actorVetId } = args;
+  const dao = new ReportDao({ dbPool });
   const conn = await dbPool.connect();
   try {
     const encryptedReportData = await toEncryptedBarkReportData(
@@ -52,10 +53,10 @@ export async function opSubmitReport(
     if (res.appointmentStatus !== APPOINTMENT_STATUS.PENDING) {
       return Err(CODE.ERROR_APPOINTMENT_IS_NOT_PENDING);
     }
-    const dao = new ReportDao(conn);
     const { reportId } = await dao.insert({
       callId: appointmentId,
       spec: encryptedReportData,
+      conn,
     });
     await updateAppointment(conn, {
       appointmentId,

--- a/src/lib/bark/operations/op-submit-report.ts
+++ b/src/lib/bark/operations/op-submit-report.ts
@@ -32,7 +32,7 @@ export async function opSubmitReport(
 > {
   const { dbPool } = context;
   const { appointmentId, reportData, actorVetId } = args;
-  const dao = new ReportDao({ dbPool });
+  const dao = new ReportDao();
   const conn = await dbPool.connect();
   try {
     const encryptedReportData = await toEncryptedBarkReportData(
@@ -56,7 +56,7 @@ export async function opSubmitReport(
     const { reportId } = await dao.insert({
       callId: appointmentId,
       spec: encryptedReportData,
-      conn,
+      db: conn,
     });
     await updateAppointment(conn, {
       appointmentId,

--- a/src/lib/bark/services/dog-profile-service.ts
+++ b/src/lib/bark/services/dog-profile-service.ts
@@ -136,7 +136,7 @@ export class DogProfileService {
       }
       const { reportCount } = await reportDao.getReportCountByDog({
         dogId,
-        conn,
+        db: conn,
       });
       if (reportCount > 0) {
         return Err(CODE.ERROR_CANNOT_UPDATE_FULL_PROFILE);
@@ -175,7 +175,7 @@ export class DogProfileService {
       }
       const { reportCount } = await reportDao.getReportCountByDog({
         dogId,
-        conn,
+        db: conn,
       });
       if (reportCount === 0) {
         return Err(CODE.ERROR_SHOULD_UPDATE_FULL_PROFILE);
@@ -294,7 +294,7 @@ export class DogProfileService {
       }
       const encrytpedReports = await reportDao.getEncryptedBarkReportsByDogId({
         dogId,
-        conn,
+        db: conn,
       });
       const futureReports = encrytpedReports.map(async (encrypted) =>
         this.toBarkReport({ encrypted }),
@@ -323,7 +323,7 @@ export class DogProfileService {
       }
       const { reportCount } = await reportDao.getReportCountByDog({
         dogId,
-        conn,
+        db: conn,
       });
       return Ok({ reportCount });
     });

--- a/tests/_fixtures.ts
+++ b/tests/_fixtures.ts
@@ -207,7 +207,7 @@ export function getUserAccountService(dbPool: Pool) {
 
 export function getDogProfileService(dbPool: Pool) {
   const context = getBarkContext(dbPool);
-  const reportDao = new ReportDao({ dbPool });
+  const reportDao = new ReportDao();
   return new DogProfileService({ context, reportDao });
 }
 

--- a/tests/_fixtures.ts
+++ b/tests/_fixtures.ts
@@ -99,6 +99,7 @@ import {
   EncryptedBarkReportData,
   EncryptedBarkReportDataSchema,
 } from "@/lib/bark/models/encrypted-bark-report-data";
+import { ReportDao } from "@/lib/bark/daos/report-dao";
 
 export function ensureTimePassed(): void {
   const t0 = new Date().getTime();
@@ -206,7 +207,8 @@ export function getUserAccountService(dbPool: Pool) {
 
 export function getDogProfileService(dbPool: Pool) {
   const context = getBarkContext(dbPool);
-  return new DogProfileService({ context });
+  const reportDao = new ReportDao({ dbPool });
+  return new DogProfileService({ context, reportDao });
 }
 
 export function mockUserAccountSpec(

--- a/tests/bark/services/dog-profile-service.test.ts
+++ b/tests/bark/services/dog-profile-service.test.ts
@@ -31,8 +31,7 @@ describe("DogProfileService", () => {
       const { userId } = await _createTestUser({ context, idx: 1 });
       const { vetId } = await _createTestVetClinic({ context, idx: 2 });
       const spec = mockDogProfileSpec({ dogPreferredVetId: vetId });
-      const { dbPool } = context;
-      const reportDao = new ReportDao({ dbPool });
+      const reportDao = new ReportDao();
       const service = new DogProfileService({ context, reportDao });
       const res1 = await service.addDogProfile({ userId, spec });
       const { dogId } = res1.result!;
@@ -59,8 +58,7 @@ describe("DogProfileService", () => {
         dogPreferredVetId: v2.vetId,
       });
 
-      const { dbPool } = context;
-      const reportDao = new ReportDao({ dbPool });
+      const reportDao = new ReportDao();
       const service = new DogProfileService({ context, reportDao });
       await service.addDogProfile({ userId, spec: spec1 });
       await service.addDogProfile({ userId, spec: spec2 });
@@ -81,8 +79,7 @@ describe("DogProfileService", () => {
       await withBarkContext(async ({ context }) => {
         const { userId } = await _createTestUser({ context, idx: 1 });
         const spec1 = mockDogProfileSpec({ dogName: "Eric" });
-        const { dbPool } = context;
-        const reportDao = new ReportDao({ dbPool });
+        const reportDao = new ReportDao();
         const service = new DogProfileService({ context, reportDao });
         const resAdd = await service.addDogProfile({ userId, spec: spec1 });
         const { dogId } = resAdd.result!;
@@ -104,8 +101,7 @@ describe("DogProfileService", () => {
       await withBarkContext(async ({ context }) => {
         const { userId } = await _createTestUser({ context, idx: 1 });
         const spec1 = mockDogProfileSpec({ dogName: "Eric" });
-        const { dbPool } = context;
-        const reportDao = new ReportDao({ dbPool });
+        const reportDao = new ReportDao();
         const service = new DogProfileService({ context, reportDao });
         const resAdd = await service.addDogProfile({ userId, spec: spec1 });
         const { dogId } = resAdd.result!;
@@ -129,8 +125,7 @@ describe("DogProfileService", () => {
           dogName: "Eric",
           dogPreferredVetId: vetId,
         });
-        const { dbPool } = context;
-        const reportDao = new ReportDao({ dbPool });
+        const reportDao = new ReportDao();
         const service = new DogProfileService({ context, reportDao });
         const resAdd = await service.addDogProfile({ userId, spec: spec1 });
         const { dogId } = resAdd.result!;
@@ -152,8 +147,7 @@ describe("DogProfileService", () => {
           dogName: "Eric",
           dogPreferredVetId: vetId,
         });
-        const { dbPool } = context;
-        const reportDao = new ReportDao({ dbPool });
+        const reportDao = new ReportDao();
         const service = new DogProfileService({ context, reportDao });
         const resAdd = await service.addDogProfile({ userId, spec: spec1 });
         const { dogId } = resAdd.result!;
@@ -182,8 +176,7 @@ describe("DogProfileService", () => {
         dogWeightKg: null,
         dogPreferredVetId: vetId,
       });
-      const { dbPool } = context;
-      const reportDao = new ReportDao({ dbPool });
+      const reportDao = new ReportDao();
       const service = new DogProfileService({ context, reportDao });
       const resAdd = await service.addDogProfile({ userId, spec: spec1 });
       const { dogId } = resAdd.result!;
@@ -207,7 +200,7 @@ async function _attachReportToDog(args: {
 }) {
   const { vetId, dogId, context, reportOverrides } = args;
   const { dbPool } = context;
-  const reportDao = new ReportDao({ dbPool });
+  const reportDao = new ReportDao();
   const res = await dbTransaction(context.dbPool, async (conn) => {
     const callDao = new CallDao(conn);
     const { callId } = await callDao.insert({
@@ -216,11 +209,14 @@ async function _attachReportToDog(args: {
     const spec = mockEncryptedBarkReportData({
       ...reportOverrides,
     });
-    const { reportId } = await reportDao.insert({ callId, spec, conn });
+    const { reportId } = await reportDao.insert({ callId, spec, db: conn });
     return Ok({ reportId, callId });
   });
   expect(res.error).toBeUndefined();
-  const { reportCount } = await reportDao.getReportCountByDog({ dogId });
+  const { reportCount } = await reportDao.getReportCountByDog({
+    dogId,
+    db: dbPool,
+  });
   expect(reportCount).toEqual(1);
   return res;
 }


### PR DESCRIPTION
Require ReportDao to be constructed from a DbPool so that it can be constructed once in AppFactory and injected into the services that require ReportDao. Optionally, where the DAO needs to operate within transactions, it can accept a conn arg.